### PR TITLE
feat: per-device profiles, background mode, CLI quick-toggles and CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @SoaOaoS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Lint with reviewdog
         run: ruff check --output-format rdjson nothing_app/ | reviewdog -f=rdjson -reporter=github-pr-review -fail-on-error
         env:
-          REVIEWDOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Still fail the job if formatting is wrong
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,17 @@ jobs:
       - name: Install ruff
         run: pip install ruff
 
-      # Posts inline review comments on the PR diff for every ruff finding
-      - uses: reviewdog/action-ruff@v1
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review      # inline comments on the diff
-          level: error
-          ruff_args: nothing_app/
+          reviewdog_version: latest
 
-      # Still fail the job if formatting is wrong (reviewdog doesn't cover format)
+      # Posts inline review comments on the PR diff for every ruff finding
+      - name: Lint with reviewdog
+        run: ruff check --output-format rdjson nothing_app/ | reviewdog -f=rdjson -reporter=github-pr-review -fail-on-error
+        env:
+          REVIEWDOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Still fail the job if formatting is wrong
       - name: Check formatting
         run: ruff format --check nothing_app/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint & format
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Check lint
+        run: ruff check nothing_app/
+
+      - name: Check formatting
+        run: ruff format --check nothing_app/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write  # needed for reviewdog to post inline comments
+
 jobs:
   lint:
     name: Lint & format
@@ -21,8 +25,14 @@ jobs:
       - name: Install ruff
         run: pip install ruff
 
-      - name: Check lint
-        run: ruff check nothing_app/
+      # Posts inline review comments on the PR diff for every ruff finding
+      - uses: reviewdog/action-ruff@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review      # inline comments on the diff
+          level: error
+          ruff_args: nothing_app/
 
+      # Still fail the job if formatting is wrong (reviewdog doesn't cover format)
       - name: Check formatting
         run: ruff format --check nothing_app/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
 - **ANC control** — Off · Noise Cancellation · Transparency (real RFCOMM protocol)
 - **EQ presets** — Balanced · More Bass · More Treble · Voice
 - **Volume slider** — controls the PulseAudio/PipeWire A2DP sink directly
+- **Per-device profiles** — ANC and EQ saved per device, restored automatically on reconnect
+- **Background mode** — closing the window keeps the app running; relaunch to reopen
+- **CLI quick-toggles** — control your earbuds without opening the GUI (see [CLI usage](#cli-usage))
+- **Low battery notifications** — `notify-send` alert when any bud drops below 20 %
 - **Firmware version & serial number** — read from the device over RFCOMM
 - **In-ear detection toggle**
 - **Device discovery** — BlueZ D-Bus; Nothing/CMF devices highlighted with a badge
@@ -103,10 +107,25 @@ something-x         # if installed via pip
 3. **Scan** — "SCAN FOR DEVICES" runs 30 s BlueZ discovery
 4. **Device page** — tap a card to open controls:
    - Battery rings (L / R / Case) update in real time
-   - ANC and EQ apply immediately over RFCOMM
+   - ANC and EQ apply immediately over RFCOMM; settings saved automatically
    - Volume slider controls the A2DP sink via `pactl`
    - Firmware and serial number shown after connection
 5. **Disconnect** — red button sends a clean BlueZ disconnect
+6. **Close** — hides to background; run `something-x` again to reopen
+
+---
+
+## CLI usage
+
+After connecting to a device at least once via the GUI, you can control it from the terminal:
+
+```bash
+something-x --battery                    # print battery levels
+something-x --anc off|on|transparency   # set ANC mode
+something-x --eq balanced|bass|treble|voice  # set EQ preset
+something-x --anc on --eq bass          # combine actions
+something-x --device AA:BB:CC:DD:EE:FF --battery  # target a specific device
+```
 
 ---
 
@@ -127,11 +146,12 @@ This project uses **Conventional Commits**. Pushing to `main` triggers automatic
 
 ```
 nothing_app/
-├── application.py      Adw.Application — CSS, dark theme, splash handoff
+├── application.py      Adw.Application — CSS, dark theme, splash, background mode, CLI
 ├── splash.py           Animated splash screen (Cairo, typewriter, ripples)
 ├── window.py           AdwNavigationView — home ↔ device routing
 ├── bluetooth.py        BlueZ D-Bus manager (discovery, connect/disconnect signals)
 ├── protocol.py         Nothing Ear RFCOMM 0x55 binary protocol (reverse-engineered)
+├── profiles.py         Per-device ANC/EQ profile persistence (~/.config/something-x/)
 ├── data/
 │   └── style.css       Nothing X glass-morphism CSS theme
 └── pages/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,9 +47,10 @@ The RFCOMM `0x55` protocol is shared across the entire Nothing Ear lineup. Confi
 
 ### Features
 - [x] **Low battery desktop notification** — `notify-send` when any bud drops below 20 %
-- [ ] **System tray / background mode** — keep running in tray, show battery on hover
-- [ ] **Per-device profiles** — save ANC + EQ settings per device address, restore on reconnect
-- [ ] **CLI quick-toggle** — `something-x --anc off`, `something-x --eq bass`, `something-x --battery`
+- [x] **Background mode** — closing the window hides it; relaunch shows it again (Gio single-instance)
+- [x] **Per-device profiles** — ANC + EQ saved per device address to `~/.config/something-x/profiles.json`, restored automatically on reconnect
+- [x] **CLI quick-toggle** — `something-x --anc off|on|transparency`, `something-x --eq bass`, `something-x --battery`
+- [ ] **System tray icon** — show battery on hover via StatusNotifierItem (Waybar/SNI)
 - [ ] **Wearing detection display** — show L/R in-ear status on the earbud visual
 - [ ] **Auto-connect RFCOMM** — connect as soon as BlueZ reports the device connected, no tap needed
 

--- a/main.py
+++ b/main.py
@@ -4,8 +4,7 @@ import os
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from nothing_app.application import SomethingXApplication
+from nothing_app.application import main
 
 if __name__ == "__main__":
-    app = SomethingXApplication()
-    sys.exit(app.run(sys.argv))
+    main()

--- a/nothing_app/application.py
+++ b/nothing_app/application.py
@@ -7,7 +7,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 gi.require_version("Gdk", "4.0")
-from gi.repository import Gtk, Adw, Gdk, Gio
+from gi.repository import Gtk, Adw, Gdk, Gio, GLib
 
 from .bluetooth import BluetoothManager
 from .window import SomethingXWindow
@@ -47,9 +47,15 @@ class SomethingXApplication(Adw.Application):
         )
         self._bt: BluetoothManager | None = None
         self._splash: SplashScreen | None = None
+        self._window: SomethingXWindow | None = None
         self.connect("activate", self._on_activate)
 
     def _on_activate(self, _app):
+        # Second launch while already running: just show the existing window
+        if self._window is not None:
+            self._window.present()
+            return
+
         _install_desktop_file()
         Adw.StyleManager.get_default().set_color_scheme(Adw.ColorScheme.FORCE_DARK)
         self._load_css()
@@ -62,10 +68,22 @@ class SomethingXApplication(Adw.Application):
 
     def _on_splash_done(self):
         win = SomethingXWindow(bt_manager=self._bt, application=self)
+        win.connect("close-request", self._on_window_close)
+        self._window = win
         win.present()
         if self._splash:
             self._splash.destroy()
             self._splash = None
+
+    def _on_window_close(self, _win):
+        # Hide instead of destroy so the app keeps running in background
+        self._window.hide()
+        subprocess.Popen(
+            ["notify-send", "-i", "audio-headphones", "Something X",
+             "Running in background. Launch again to reopen."],
+            start_new_session=True,
+        )
+        return True  # prevent default close/destroy
 
     def _load_css(self):
         provider = Gtk.CssProvider()
@@ -84,6 +102,130 @@ class SomethingXApplication(Adw.Application):
             )
 
 
+# ── CLI quick-toggle mode ─────────────────────────────────────────────────────
+
+_ANC_ALIASES = {
+    "off": 0, "0": 0,
+    "on": 1, "anc": 1, "noise": 1,
+    "transparency": 2, "trans": 2, "passthrough": 2,
+}
+
+_EQ_ALIASES = {
+    "balanced": "Balanced",
+    "bass": "More Bass",
+    "treble": "More Treble",
+    "voice": "Voice",
+}
+
+
+def _run_cli(argv: list[str]) -> int:
+    from . import protocol as _proto
+    _proto._QUIET = True
+    from .protocol import NothingDevice, ANCMode, EQ_PRESETS
+    from . import profiles
+
+    address = None
+    if "--device" in argv:
+        idx = argv.index("--device")
+        if idx + 1 < len(argv):
+            address = argv[idx + 1]
+
+    if address is None:
+        address = profiles.get_last_device()
+
+    if address is None:
+        print(
+            "No known device. Open the GUI and connect to a device first,\n"
+            "or pass --device AA:BB:CC:DD:EE:FF.",
+            file=sys.stderr,
+        )
+        return 1
+
+    loop = GLib.MainLoop()
+    dev = NothingDevice(address)
+    exit_code = [0]
+    _acted = [False]
+
+    def _act():
+        if _acted[0]:
+            return False
+        _acted[0] = True
+
+        if "--battery" in argv:
+            s = dev.state
+            parts = []
+            if s.left_battery >= 0:
+                parts.append(f"Left: {s.left_battery}%")
+            if s.right_battery >= 0:
+                parts.append(f"Right: {s.right_battery}%")
+            if s.case_battery >= 0:
+                parts.append(f"Case: {s.case_battery}%")
+            print("  ".join(parts) if parts else "No battery data received.")
+
+        if "--anc" in argv:
+            idx = argv.index("--anc")
+            val = argv[idx + 1] if idx + 1 < len(argv) else ""
+            mode = _ANC_ALIASES.get(val.lower())
+            if mode is None:
+                print(f"Unknown ANC value '{val}'. Use: off, on, transparency", file=sys.stderr)
+                exit_code[0] = 1
+            else:
+                dev.set_anc_mode(mode)
+                print(f"ANC → {ANCMode.LABELS.get(mode)}")
+
+        if "--eq" in argv:
+            idx = argv.index("--eq")
+            val = argv[idx + 1] if idx + 1 < len(argv) else ""
+            preset = _EQ_ALIASES.get(val.lower())
+            if preset is None:
+                print(f"Unknown EQ preset '{val}'. Use: balanced, bass, treble, voice", file=sys.stderr)
+                exit_code[0] = 1
+            else:
+                dev.set_eq_preset(preset)
+                print(f"EQ → {preset}")
+
+        GLib.timeout_add(600, loop.quit)
+        return False
+
+    def _on_state_changed(_d):
+        if dev.state.left_battery >= 0 or dev.state.right_battery >= 0:
+            _act()
+
+    def _on_timeout():
+        print("Timeout: device did not respond in time.", file=sys.stderr)
+        exit_code[0] = 1
+        loop.quit()
+        return False
+
+    dev.connect("state-changed", _on_state_changed)
+    dev.connect_rfcomm()
+    GLib.timeout_add(12000, _on_timeout)
+    loop.run()
+    dev.disconnect_rfcomm()
+    return exit_code[0]
+
+
+def _print_help():
+    print(
+        "Usage:\n"
+        "  something-x                             launch GUI\n"
+        "  something-x --battery                   print battery levels\n"
+        "  something-x --anc off|on|transparency   set ANC mode\n"
+        "  something-x --eq balanced|bass|treble|voice  set EQ preset\n"
+        "  something-x --device AA:BB:CC:DD:EE:FF  target specific device\n"
+    )
+
+
 def main():
+    argv = sys.argv[1:]
+    cli_flags = {"--battery", "--anc", "--eq"}
+
+    if "--help" in argv or "-h" in argv:
+        _print_help()
+        sys.exit(0)
+
+    if any(f in argv for f in cli_flags):
+        sys.exit(_run_cli(argv))
+
     app = SomethingXApplication()
     sys.exit(app.run(sys.argv))

--- a/nothing_app/application.py
+++ b/nothing_app/application.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import importlib.resources
 import gi
+
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 gi.require_version("Gdk", "4.0")
@@ -36,6 +37,7 @@ def _css_path() -> str:
         return str(ref)
     except Exception:
         import os
+
         return os.path.join(os.path.dirname(__file__), "data", "style.css")
 
 
@@ -79,8 +81,13 @@ class SomethingXApplication(Adw.Application):
         # Hide instead of destroy so the app keeps running in background
         self._window.hide()
         subprocess.Popen(
-            ["notify-send", "-i", "audio-headphones", "Something X",
-             "Running in background. Launch again to reopen."],
+            [
+                "notify-send",
+                "-i",
+                "audio-headphones",
+                "Something X",
+                "Running in background. Launch again to reopen.",
+            ],
             start_new_session=True,
         )
         return True  # prevent default close/destroy
@@ -105,9 +112,14 @@ class SomethingXApplication(Adw.Application):
 # ── CLI quick-toggle mode ─────────────────────────────────────────────────────
 
 _ANC_ALIASES = {
-    "off": 0, "0": 0,
-    "on": 1, "anc": 1, "noise": 1,
-    "transparency": 2, "trans": 2, "passthrough": 2,
+    "off": 0,
+    "0": 0,
+    "on": 1,
+    "anc": 1,
+    "noise": 1,
+    "transparency": 2,
+    "trans": 2,
+    "passthrough": 2,
 }
 
 _EQ_ALIASES = {
@@ -120,6 +132,7 @@ _EQ_ALIASES = {
 
 def _run_cli(argv: list[str]) -> int:
     from . import protocol as _proto
+
     _proto._QUIET = True
     from .protocol import NothingDevice, ANCMode
     from . import profiles

--- a/nothing_app/application.py
+++ b/nothing_app/application.py
@@ -121,7 +121,7 @@ _EQ_ALIASES = {
 def _run_cli(argv: list[str]) -> int:
     from . import protocol as _proto
     _proto._QUIET = True
-    from .protocol import NothingDevice, ANCMode, EQ_PRESETS
+    from .protocol import NothingDevice, ANCMode
     from . import profiles
 
     address = None

--- a/nothing_app/bluetooth.py
+++ b/nothing_app/bluetooth.py
@@ -10,8 +10,14 @@ OBJ_MANAGER_IFACE = "org.freedesktop.DBus.ObjectManager"
 PROPERTIES_IFACE = "org.freedesktop.DBus.Properties"
 
 NOTHING_PATTERNS = (
-    "nothing ear", "ear (1)", "ear (2)", "ear (a)", "ear (stick)",
-    "cmf buds", "cmf earphone", "nothing phone",
+    "nothing ear",
+    "ear (1)",
+    "ear (2)",
+    "ear (a)",
+    "ear (stick)",
+    "cmf buds",
+    "cmf earphone",
+    "nothing phone",
 )
 
 
@@ -157,14 +163,14 @@ class BluetoothManager(GObject.Object):
     def connect_device(self, path: str, on_error=None):
         if not self._bus:
             return
+
         def _err(e):
             print(f"[BT] connect error: {e}")
             if on_error:
                 GLib.idle_add(on_error)
+
         try:
-            iface = dbus.Interface(
-                self._bus.get_object(BLUEZ_SERVICE, path), DEVICE_IFACE
-            )
+            iface = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, path), DEVICE_IFACE)
             iface.Connect(reply_handler=lambda: None, error_handler=_err)
         except Exception as exc:
             print(f"[bluetooth] connect {path}: {exc}")
@@ -175,9 +181,7 @@ class BluetoothManager(GObject.Object):
         if not self._bus:
             return
         try:
-            iface = dbus.Interface(
-                self._bus.get_object(BLUEZ_SERVICE, path), DEVICE_IFACE
-            )
+            iface = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, path), DEVICE_IFACE)
             iface.Disconnect(
                 reply_handler=lambda: None,
                 error_handler=lambda e: print(f"[BT] disconnect error: {e}"),
@@ -189,14 +193,10 @@ class BluetoothManager(GObject.Object):
         if not self._bus:
             return
         try:
-            mgr = dbus.Interface(
-                self._bus.get_object(BLUEZ_SERVICE, "/"), OBJ_MANAGER_IFACE
-            )
+            mgr = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, "/"), OBJ_MANAGER_IFACE)
             for path, ifaces in mgr.GetManagedObjects().items():
                 if ADAPTER_IFACE in ifaces:
-                    adapter = dbus.Interface(
-                        self._bus.get_object(BLUEZ_SERVICE, path), ADAPTER_IFACE
-                    )
+                    adapter = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, path), ADAPTER_IFACE)
                     adapter.StartDiscovery()
                     GLib.timeout_add_seconds(30, self._stop_discovery_on_path, str(path))
                     break
@@ -205,9 +205,7 @@ class BluetoothManager(GObject.Object):
 
     def _stop_discovery_on_path(self, path: str):
         try:
-            adapter = dbus.Interface(
-                self._bus.get_object(BLUEZ_SERVICE, path), ADAPTER_IFACE
-            )
+            adapter = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, path), ADAPTER_IFACE)
             adapter.StopDiscovery()
         except Exception:
             pass

--- a/nothing_app/pages/device.py
+++ b/nothing_app/pages/device.py
@@ -4,12 +4,14 @@ import subprocess
 import threading
 import cairo
 import gi
+
 gi.require_version("Gtk", "4.0")
 gi.require_version("Pango", "1.0")
 gi.require_version("PangoCairo", "1.0")
 from gi.repository import Gtk, GLib, PangoCairo
 
 from ..bluetooth import BluetoothDevice, BluetoothManager
+
 
 def _mono_font() -> str:
     available = {f.get_name() for f in PangoCairo.FontMap.get_default().list_families()}
@@ -18,20 +20,23 @@ def _mono_font() -> str:
             return name
     return "monospace"
 
+
 _MONO = _mono_font()
 from ..protocol import NothingDevice, ANCMode, EQ_PRESETS
 
 
 def _find_bt_sink(address: str) -> str | None:
-    addr_key = address.replace(':', '_').lower()
+    addr_key = address.replace(":", "_").lower()
     try:
         out = subprocess.run(
             ["pactl", "list", "short", "sinks"],
-            capture_output=True, text=True, timeout=2,
+            capture_output=True,
+            text=True,
+            timeout=2,
         ).stdout
         for line in out.splitlines():
             if addr_key in line.lower():
-                parts = line.split('\t')
+                parts = line.split("\t")
                 if len(parts) >= 2:
                     return parts[1].strip()
     except Exception:
@@ -46,9 +51,11 @@ def _get_sink_volume(address: str) -> int | None:
     try:
         out = subprocess.run(
             ["pactl", "get-sink-volume", sink],
-            capture_output=True, text=True, timeout=2,
+            capture_output=True,
+            text=True,
+            timeout=2,
         ).stdout
-        m = re.search(r'(\d+)%', out)
+        m = re.search(r"(\d+)%", out)
         return int(m.group(1)) if m else None
     except Exception:
         return None
@@ -61,7 +68,8 @@ def _set_sink_volume(address: str, pct: int):
     try:
         subprocess.run(
             ["pactl", "set-sink-volume", sink, f"{pct}%"],
-            capture_output=True, timeout=2,
+            capture_output=True,
+            timeout=2,
         )
     except Exception:
         pass
@@ -394,20 +402,24 @@ class DevicePage(Gtk.Box):
         self._in_ear_switch.set_active(True)
         self._in_ear_switch.set_valign(Gtk.Align.CENTER)
         self._in_ear_switch.connect("state-set", self._on_in_ear_toggled)
-        settings_group.append(_settings_row(
-            "In-Ear Detection",
-            "Pause when earbuds are removed",
-            self._in_ear_switch,
-        ))
+        settings_group.append(
+            _settings_row(
+                "In-Ear Detection",
+                "Pause when earbuds are removed",
+                self._in_ear_switch,
+            )
+        )
 
         self._auto_pause_switch = Gtk.Switch()
         self._auto_pause_switch.set_active(True)
         self._auto_pause_switch.set_valign(Gtk.Align.CENTER)
-        settings_group.append(_settings_row(
-            "Auto-Pause",
-            "Pause media on removal",
-            self._auto_pause_switch,
-        ))
+        settings_group.append(
+            _settings_row(
+                "Auto-Pause",
+                "Pause media on removal",
+                self._auto_pause_switch,
+            )
+        )
 
         page.append(settings_group)
 
@@ -499,6 +511,7 @@ class DevicePage(Gtk.Box):
             pct = _get_sink_volume(self._bt_device.address)
             if pct is not None:
                 GLib.idle_add(self._apply_vol_display, pct)
+
         threading.Thread(target=_run, daemon=True).start()
         return False
 
@@ -519,9 +532,7 @@ class DevicePage(Gtk.Box):
 
     def _do_set_volume(self, pct: int):
         self._vol_debounce_id = None
-        threading.Thread(
-            target=_set_sink_volume, args=(self._bt_device.address, pct), daemon=True
-        ).start()
+        threading.Thread(target=_set_sink_volume, args=(self._bt_device.address, pct), daemon=True).start()
         return False
 
     def _sync_anc_ui(self, active_mode: int):
@@ -577,6 +588,7 @@ class DevicePage(Gtk.Box):
         self._update_status_label()
         if self._nothing_dev:
             from .. import profiles
+
             profiles.set_last_device(self._bt_device.address)
             self._nothing_dev.connect_rfcomm()
 

--- a/nothing_app/pages/device.py
+++ b/nothing_app/pages/device.py
@@ -576,6 +576,8 @@ class DevicePage(Gtk.Box):
         self._update_conn_button()
         self._update_status_label()
         if self._nothing_dev:
+            from .. import profiles
+            profiles.set_last_device(self._bt_device.address)
             self._nothing_dev.connect_rfcomm()
 
     def _on_bt_device_disconnected(self, _manager, path: str):

--- a/nothing_app/pages/device.py
+++ b/nothing_app/pages/device.py
@@ -7,7 +7,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Pango", "1.0")
 gi.require_version("PangoCairo", "1.0")
-from gi.repository import Gtk, GLib, GObject, Gdk, Pango, PangoCairo
+from gi.repository import Gtk, GLib, PangoCairo
 
 from ..bluetooth import BluetoothDevice, BluetoothManager
 
@@ -19,7 +19,7 @@ def _mono_font() -> str:
     return "monospace"
 
 _MONO = _mono_font()
-from ..protocol import NothingDevice, ANCMode, EQ_PRESETS, DeviceState
+from ..protocol import NothingDevice, ANCMode, EQ_PRESETS
 
 
 def _find_bt_sink(address: str) -> str | None:

--- a/nothing_app/pages/home.py
+++ b/nothing_app/pages/home.py
@@ -1,4 +1,5 @@
 import gi
+
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib, GObject
 
@@ -45,12 +46,8 @@ class DeviceRow(Gtk.Box):
         text_box.append(addr_lbl)
 
         bottom_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        status_lbl = Gtk.Label(
-            label="● Connected" if self.device.connected else "○ Disconnected"
-        )
-        status_lbl.add_css_class(
-            "status-connected" if self.device.connected else "status-disconnected"
-        )
+        status_lbl = Gtk.Label(label="● Connected" if self.device.connected else "○ Disconnected")
+        status_lbl.add_css_class("status-connected" if self.device.connected else "status-disconnected")
         status_lbl.set_xalign(0)
         bottom_row.append(status_lbl)
 
@@ -152,9 +149,7 @@ class HomePage(Gtk.Box):
         scan_row.append(self._scan_btn)
         self._content.append(scan_row)
 
-        self._bt_warning = Gtk.Label(
-            label="⚠  Bluetooth unavailable — is bluetoothd running?"
-        )
+        self._bt_warning = Gtk.Label(label="⚠  Bluetooth unavailable — is bluetoothd running?")
         self._bt_warning.add_css_class("empty-subtitle")
         self._bt_warning.set_margin_top(8)
         self._bt_warning.set_halign(Gtk.Align.CENTER)

--- a/nothing_app/profiles.py
+++ b/nothing_app/profiles.py
@@ -1,0 +1,41 @@
+import json
+import os
+
+_DIR = os.path.expanduser("~/.config/something-x")
+_PROFILES_FILE = os.path.join(_DIR, "profiles.json")
+_LAST_DEV_FILE = os.path.join(_DIR, "last_device")
+
+
+def load(address: str) -> dict:
+    try:
+        with open(_PROFILES_FILE) as f:
+            return json.load(f).get(address, {})
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save(address: str, anc_mode: int, eq_preset: str):
+    os.makedirs(_DIR, exist_ok=True)
+    data = {}
+    try:
+        with open(_PROFILES_FILE) as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+    data[address] = {"anc": anc_mode, "eq": eq_preset}
+    with open(_PROFILES_FILE, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def get_last_device() -> str | None:
+    try:
+        addr = open(_LAST_DEV_FILE).read().strip()
+        return addr or None
+    except FileNotFoundError:
+        return None
+
+
+def set_last_device(address: str):
+    os.makedirs(_DIR, exist_ok=True)
+    with open(_LAST_DEV_FILE, "w") as f:
+        f.write(address)

--- a/nothing_app/protocol.py
+++ b/nothing_app/protocol.py
@@ -4,7 +4,7 @@ import struct
 import subprocess
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from gi.repository import GLib, GObject
 
 _DEBUG = bool(os.getenv("SOMETHING_X_DEBUG"))
@@ -307,7 +307,7 @@ class NothingDevice(GObject.Object):
                 data += chunk
                 if len(data) >= 4:
                     break
-        except socket.timeout:
+        except TimeoutError:
             pass
 
         if not data:
@@ -336,7 +336,7 @@ class NothingDevice(GObject.Object):
                     _log(f"[RX RAW] {chunk.hex()}")
                 buf += chunk
                 buf = self._process_buf(buf)
-            except socket.timeout:
+            except TimeoutError:
                 continue
             except OSError:
                 break

--- a/nothing_app/protocol.py
+++ b/nothing_app/protocol.py
@@ -15,6 +15,7 @@ def _log(*args, **kwargs):
     if not _QUIET:
         print(*args, **kwargs)
 
+
 # ── 0x55 protocol (from APK decompilation: Nothing Ear 3 / Donphan) ────────────
 #
 # Frame layout (both directions):
@@ -30,22 +31,22 @@ def _log(*args, **kwargs):
 # CRC covers: SOF + ctrl(2) + cmd(2) + len(2) + FSN + payload
 # CRC16-IBM/ARC: init=0xFFFF, poly=0xA001 (reflected 0x8005)
 
-_SOF           = 0x55
-_CTRL_HOST_CRC = 0x0160   # all outgoing frames: CRC + multiFrames + deviceType=1
+_SOF = 0x55
+_CTRL_HOST_CRC = 0x0160  # all outgoing frames: CRC + multiFrames + deviceType=1
 
 # Query commands (0xC0xx) – app→device, response has bit15 cleared
-_CMD_PROTO_VERSION  = 0xC001   # activation handshake (isNeedActivate=true)
-_CMD_REMOTE_CONF    = 0xC006   # GET_REMOTE_CONFIGURATION — serial number (UTF-8 string)
-_CMD_BATTERY        = 0xC007
-_CMD_EARPHONE       = 0xC00A
-_CMD_NOISE_RED      = 0xC01E   # get ANC state; payload [0x03] = request 3 entries
-_CMD_EQ_MODE        = 0xC01F
-_CMD_HOST_VERSION   = 0xC042   # GET_HOST_VERSION_DEVICE — firmware version (UTF-8 string)
+_CMD_PROTO_VERSION = 0xC001  # activation handshake (isNeedActivate=true)
+_CMD_REMOTE_CONF = 0xC006  # GET_REMOTE_CONFIGURATION — serial number (UTF-8 string)
+_CMD_BATTERY = 0xC007
+_CMD_EARPHONE = 0xC00A
+_CMD_NOISE_RED = 0xC01E  # get ANC state; payload [0x03] = request 3 entries
+_CMD_EQ_MODE = 0xC01F
+_CMD_HOST_VERSION = 0xC042  # GET_HOST_VERSION_DEVICE — firmware version (UTF-8 string)
 
 # SET commands (0xF0xx) – app→device, ACK has bit15 cleared
-_CMD_SET_ACTIVATED  = 0xF001   # activation response; no payload
-_CMD_SET_NOISE_RED  = 0xF00F   # payload: [0x01, anc_val, 0x00]
-_CMD_SET_EQ         = 0xF010   # payload: [eq_val]
+_CMD_SET_ACTIVATED = 0xF001  # activation response; no payload
+_CMD_SET_NOISE_RED = 0xF00F  # payload: [0x01, anc_val, 0x00]
+_CMD_SET_EQ = 0xF010  # payload: [eq_val]
 
 
 def _crc16(data: bytes) -> int:
@@ -56,34 +57,35 @@ def _crc16(data: bytes) -> int:
             crc = (crc >> 1) ^ 0xA001 if (crc & 1) else crc >> 1
     return crc & 0xFFFF
 
+
 # Device event notifications (0xE0xx) – device→app, bit15 always set
-_EVT_BATTERY        = 0xE001
-_EVT_STATUS         = 0xE002
-_EVT_NOISE_RED      = 0xE003
+_EVT_BATTERY = 0xE001
+_EVT_STATUS = 0xE002
+_EVT_NOISE_RED = 0xE003
 
 # Battery payload: [type:1][val:1] pairs
 #   type 2=left  3=right  4=case
 #   val: bit7=charging, bits[6:0]=percent
-_BAT_LEFT  = 2
+_BAT_LEFT = 2
 _BAT_RIGHT = 3
-_BAT_CASE  = 4
+_BAT_CASE = 4
 
 # ANC wire values for SET_NOISE_RED payload byte [1] (type=1 = NOISE_REDUCTION_MODE triplet)
 # These are MODE constants from DeviceNoiseReduction.java, NOT the VALUE constants.
 # VALUE_NOISE_REDUCTION_CLOSE=0 and VALUE_PASS_THROUGH=0xFE are for type=2 (level) entries.
-_ANC_OFF          = 5    # MODE_NOISE_REDUCTION_CLOSE
-_ANC_STRONG       = 1    # MODE_NOISE_REDUCTION_STRONG  (confirmed working)
-_ANC_MEDIUM       = 2    # MODE_NOISE_REDUCTION_MEDIUM
-_ANC_WEAK         = 3    # MODE_NOISE_REDUCTION_WEAK
-_ANC_TRANSPARENCY = 7    # MODE_PASS_THROUGH
+_ANC_OFF = 5  # MODE_NOISE_REDUCTION_CLOSE
+_ANC_STRONG = 1  # MODE_NOISE_REDUCTION_STRONG  (confirmed working)
+_ANC_MEDIUM = 2  # MODE_NOISE_REDUCTION_MEDIUM
+_ANC_WEAK = 3  # MODE_NOISE_REDUCTION_WEAK
+_ANC_TRANSPARENCY = 7  # MODE_PASS_THROUGH
 
 # ── Legacy 0x03/0x02 protocol (ch17 status-only stream) ──────────────────────
 # Still used for battery parsing from the old status channel fallback.
-_L_DEV_HDR    = 0x03
-_L_HOST_HDR   = 0x02
-_L_INIT       = 0x01   # init handshake, echo back
-_L_STATE      = 0x02
-_L_BATTERY    = 0x03
+_L_DEV_HDR = 0x03
+_L_HOST_HDR = 0x02
+_L_INIT = 0x01  # init handshake, echo back
+_L_STATE = 0x02
+_L_BATTERY = 0x03
 
 # ── Channel probe priority ───────────────────────────────────────────────────
 _PROBE_CHANNELS = [15, 17, 16, 18, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
@@ -91,44 +93,46 @@ _PROBE_CHANNELS = [15, 17, 16, 18, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
 
 # ── Public enumerations ──────────────────────────────────────────────────────
 
+
 class ANCMode:
-    OFF               = 0
+    OFF = 0
     NOISE_CANCELLATION = 1
-    TRANSPARENCY      = 2
+    TRANSPARENCY = 2
     LABELS = {OFF: "Off", NOISE_CANCELLATION: "ANC", TRANSPARENCY: "Transparency"}
 
 
 EQ_PRESETS = {
-    "Balanced":    0,
-    "More Bass":   1,
+    "Balanced": 0,
+    "More Bass": 1,
     "More Treble": 2,
-    "Voice":       3,
+    "Voice": 3,
 }
 EQ_PRESET_NAMES = {v: k for k, v in EQ_PRESETS.items()}
 
 
 @dataclass
 class DeviceState:
-    left_battery:     int  = -1
-    right_battery:    int  = -1
-    case_battery:     int  = -1
-    anc_mode:         int  = ANCMode.OFF
-    eq_preset:        str  = "Balanced"
+    left_battery: int = -1
+    right_battery: int = -1
+    case_battery: int = -1
+    anc_mode: int = ANCMode.OFF
+    eq_preset: str = "Balanced"
     in_ear_detection: bool = True
-    auto_pause:       bool = True
-    firmware_version: str  = "—"
-    serial_number:    str  = "—"
-    left_wearing:     bool = False
-    right_wearing:    bool = False
+    auto_pause: bool = True
+    firmware_version: str = "—"
+    serial_number: str = "—"
+    left_wearing: bool = False
+    right_wearing: bool = False
 
 
 # ── Device class ─────────────────────────────────────────────────────────────
 
+
 class NothingDevice(GObject.Object):
     __gsignals__ = {
         "state-changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
-        "connected":     (GObject.SignalFlags.RUN_FIRST, None, ()),
-        "disconnected":  (GObject.SignalFlags.RUN_FIRST, None, ()),
+        "connected": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        "disconnected": (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     def __init__(self, address: str):
@@ -150,6 +154,7 @@ class NothingDevice(GObject.Object):
     def connect_rfcomm(self):
         if self._thread and self._thread.is_alive():
             return
+
         def _run():
             channels = self._discover_channels()
             for ch in channels:
@@ -198,6 +203,7 @@ class NothingDevice(GObject.Object):
         self._anc_pending_mode = mode
         self._anc_debounce_id = GLib.timeout_add(300, self._do_set_anc)
         from . import profiles
+
         profiles.save(self.address, mode, self.state.eq_preset)
 
     def _do_set_anc(self):
@@ -205,8 +211,11 @@ class NothingDevice(GObject.Object):
         if not self._activated:
             return False
         mode = self._anc_pending_mode
-        val = _ANC_TRANSPARENCY if mode == ANCMode.TRANSPARENCY else (
-              _ANC_OFF if mode == ANCMode.OFF else _ANC_STRONG)
+        val = (
+            _ANC_TRANSPARENCY
+            if mode == ANCMode.TRANSPARENCY
+            else (_ANC_OFF if mode == ANCMode.OFF else _ANC_STRONG)
+        )
         label = ANCMode.LABELS.get(mode, mode)
         self._x55_send(_CMD_SET_NOISE_RED, bytes([0x01, val, 0x00]), label=f"ANC={label}")
         return False
@@ -219,6 +228,7 @@ class NothingDevice(GObject.Object):
         eq_val = EQ_PRESETS.get(preset, 0)
         self._x55_send(_CMD_SET_EQ, bytes([eq_val]), label=f"EQ={preset}")
         from . import profiles
+
         profiles.save(self.address, self.state.anc_mode, preset)
 
     def set_in_ear_detection(self, enabled: bool):
@@ -230,6 +240,7 @@ class NothingDevice(GObject.Object):
     def _discover_channels(self) -> list[int]:
         try:
             import bluetooth as pybluez  # type: ignore
+
             services = pybluez.find_service(address=self.address)
             channels = [s["port"] for s in services if isinstance(s.get("port"), int)]
             if channels:
@@ -243,7 +254,9 @@ class NothingDevice(GObject.Object):
         try:
             out = subprocess.run(
                 ["sdptool", "browse", self.address],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             ).stdout
             channels = []
             for line in out.splitlines():
@@ -268,14 +281,13 @@ class NothingDevice(GObject.Object):
     def _try_channel(self, ch: int) -> tuple[socket.socket, bytes] | None:
         for attempt in range(2):
             try:
-                sock = socket.socket(
-                    socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM
-                )
+                sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM)
                 sock.settimeout(5)
                 sock.connect((self.address, ch))
                 break
             except OSError as exc:
                 import errno as _errno
+
                 if exc.errno == _errno.EBUSY and attempt == 0:
                     _log(f"[protocol] ch{ch}: busy — waiting 3s for stale connection to release")
                     sock.close()
@@ -288,8 +300,8 @@ class NothingDevice(GObject.Object):
 
         # Probe with GET_PROTOCOL_VERSION — use CRC to match official app (sendDataNeedCrc=true)
         _probe_hdr = struct.pack("<BHHH", _SOF, _CTRL_HOST_CRC, _CMD_PROTO_VERSION, 0) + bytes([0x01])
-        probe_x55  = _probe_hdr + struct.pack("<H", _crc16(_probe_hdr))
-        probe_leg  = bytes([_L_HOST_HDR, _L_BATTERY, 0x00, 0x00])
+        probe_x55 = _probe_hdr + struct.pack("<H", _crc16(_probe_hdr))
+        probe_leg = bytes([_L_HOST_HDR, _L_BATTERY, 0x00, 0x00])
         try:
             sock.sendall(probe_x55 + probe_leg)
         except OSError:
@@ -315,8 +327,9 @@ class NothingDevice(GObject.Object):
             sock.close()
             return None
 
-        proto = "0x55" if data[0] == _SOF else (
-                "0x03-legacy" if data[0] == _L_DEV_HDR else f"0x{data[0]:02x}")
+        proto = (
+            "0x55" if data[0] == _SOF else ("0x03-legacy" if data[0] == _L_DEV_HDR else f"0x{data[0]:02x}")
+        )
         _log(f"[protocol] ch{ch}: {proto} — {data.hex()}")
         sock.settimeout(6)
         return sock, data
@@ -386,11 +399,11 @@ class NothingDevice(GObject.Object):
                 break
             if crc_size:
                 rx_crc = struct.unpack_from("<H", buf, 8 + length)[0]
-                ok_crc = _crc16(buf[:8 + length])
+                ok_crc = _crc16(buf[: 8 + length])
                 if rx_crc != ok_crc:
                     _log(f"[RX CRC ERR] got 0x{rx_crc:04X} expected 0x{ok_crc:04X}")
-            payload = buf[8:8 + length]
-            cmd_id = cmd_raw | 0x8000   # normalize response→request ID
+            payload = buf[8 : 8 + length]
+            cmd_id = cmd_raw | 0x8000  # normalize response→request ID
             self._dispatch_x55(cmd_id, payload)
             buf = buf[total:]
         return buf
@@ -406,6 +419,7 @@ class NothingDevice(GObject.Object):
             _log(f"[RX INFO] activation ACK payload={payload.hex()}")
             self._activated = True
             from . import profiles
+
             profiles.set_last_device(self.address)
             # Always resend on real ACK — fallback may have sent queries before
             # the device finished activating and silently dropped them.
@@ -453,8 +467,8 @@ class NothingDevice(GObject.Object):
             if i + 1 >= len(payload):
                 break
             btype = payload[i]
-            bval  = payload[i + 1]
-            pct   = bval & 0x7F
+            bval = payload[i + 1]
+            pct = bval & 0x7F
             if btype == _BAT_LEFT and pct != self.state.left_battery:
                 self.state.left_battery = pct
                 self._check_low_battery("left", pct, "Left earbud")
@@ -468,8 +482,10 @@ class NothingDevice(GObject.Object):
                 self._check_low_battery("case", pct, "Case")
                 changed = True
         if changed:
-            _log(f"[protocol] battery L={self.state.left_battery}% "
-                  f"R={self.state.right_battery}% C={self.state.case_battery}%")
+            _log(
+                f"[protocol] battery L={self.state.left_battery}% "
+                f"R={self.state.right_battery}% C={self.state.case_battery}%"
+            )
         return changed
 
     def _parse_anc(self, payload: bytes) -> bool:
@@ -507,10 +523,10 @@ class NothingDevice(GObject.Object):
             if i + 1 >= len(payload):
                 break
             etype = payload[i]
-            val   = payload[i + 1]
-            in_ear    = bool(val & 0x04)
+            val = payload[i + 1]
+            in_ear = bool(val & 0x04)
             connected = bool(val & 0x80)
-            wearing   = in_ear and connected
+            wearing = in_ear and connected
             if etype == 2 and wearing != self.state.left_wearing:
                 self.state.left_wearing = wearing
                 changed = True
@@ -528,24 +544,25 @@ class NothingDevice(GObject.Object):
             if len(buf) < 4:
                 break
             msg_type = buf[1]
-            length   = struct.unpack(">H", buf[2:4])[0]
+            length = struct.unpack(">H", buf[2:4])[0]
             if len(buf) < 4 + length:
                 break
-            self._dispatch_legacy(msg_type, buf[4:4 + length])
-            buf = buf[4 + length:]
+            self._dispatch_legacy(msg_type, buf[4 : 4 + length])
+            buf = buf[4 + length :]
         return buf
 
     def _dispatch_legacy(self, msg_type: int, payload: bytes):
         if msg_type == _L_BATTERY and len(payload) >= 2:
-            self.state.left_battery  = payload[0] if payload[0] <= 100 else -1
+            self.state.left_battery = payload[0] if payload[0] <= 100 else -1
             self.state.right_battery = payload[1] if payload[1] <= 100 else -1
-            self.state.case_battery  = (payload[2] if len(payload) >= 3
-                                        and payload[2] <= 100 else -1)
-            _log(f"[protocol] legacy battery L={self.state.left_battery}% "
-                  f"R={self.state.right_battery}% C={self.state.case_battery}%")
-            self._check_low_battery("left",  self.state.left_battery,  "Left earbud")
+            self.state.case_battery = payload[2] if len(payload) >= 3 and payload[2] <= 100 else -1
+            _log(
+                f"[protocol] legacy battery L={self.state.left_battery}% "
+                f"R={self.state.right_battery}% C={self.state.case_battery}%"
+            )
+            self._check_low_battery("left", self.state.left_battery, "Left earbud")
             self._check_low_battery("right", self.state.right_battery, "Right earbud")
-            self._check_low_battery("case",  self.state.case_battery,  "Case")
+            self._check_low_battery("case", self.state.case_battery, "Case")
             GLib.idle_add(self.emit, "state-changed")
         elif msg_type == _L_INIT and payload:
             _log(f"[protocol] legacy init: {payload.hex()} — echoing back")
@@ -565,15 +582,22 @@ class NothingDevice(GObject.Object):
 
     def _restore_profile(self):
         from . import profiles
+
         p = profiles.load(self.address)
         if not p:
             return
         if "anc" in p:
             anc = p["anc"]
-            wire = (_ANC_TRANSPARENCY if anc == ANCMode.TRANSPARENCY
-                    else _ANC_OFF if anc == ANCMode.OFF else _ANC_STRONG)
-            self._x55_send(_CMD_SET_NOISE_RED, bytes([0x01, wire, 0x00]),
-                           label=f"restore ANC={ANCMode.LABELS.get(anc)}")
+            wire = (
+                _ANC_TRANSPARENCY
+                if anc == ANCMode.TRANSPARENCY
+                else _ANC_OFF
+                if anc == ANCMode.OFF
+                else _ANC_STRONG
+            )
+            self._x55_send(
+                _CMD_SET_NOISE_RED, bytes([0x01, wire, 0x00]), label=f"restore ANC={ANCMode.LABELS.get(anc)}"
+            )
         if "eq" in p:
             eq_val = EQ_PRESETS.get(p["eq"], 0)
             self._x55_send(_CMD_SET_EQ, bytes([eq_val]), label=f"restore EQ={p['eq']}")
@@ -585,8 +609,17 @@ class NothingDevice(GObject.Object):
             self._low_bat_notified.add(slot)
             threading.Thread(
                 target=subprocess.run,
-                args=(["notify-send", "-u", "critical", "-i", "battery-caution",
-                       "Something X", f"{label}: {pct}% battery remaining"],),
+                args=(
+                    [
+                        "notify-send",
+                        "-u",
+                        "critical",
+                        "-i",
+                        "battery-caution",
+                        "Something X",
+                        f"{label}: {pct}% battery remaining",
+                    ],
+                ),
                 kwargs={"capture_output": True},
                 daemon=True,
             ).start()

--- a/nothing_app/protocol.py
+++ b/nothing_app/protocol.py
@@ -8,6 +8,12 @@ from dataclasses import dataclass, field
 from gi.repository import GLib, GObject
 
 _DEBUG = bool(os.getenv("SOMETHING_X_DEBUG"))
+_QUIET = False
+
+
+def _log(*args, **kwargs):
+    if not _QUIET:
+        print(*args, **kwargs)
 
 # ── 0x55 protocol (from APK decompilation: Nothing Ear 3 / Donphan) ────────────
 #
@@ -153,13 +159,13 @@ class NothingDevice(GObject.Object):
                 sock, initial = result
                 self._sock = sock
                 self._rfcomm_connected = True
-                print(f"[protocol] using ch{ch}")
+                _log(f"[protocol] using ch{ch}")
                 GLib.idle_add(self.emit, "connected")
                 # The probe already sent GET_PROTOCOL_VERSION; the response is
                 # in `initial` and will trigger activation + queries inside recv_loop.
                 self._recv_loop(initial)
                 return
-            print(
+            _log(
                 f"[protocol] no responsive channel found for {self.address}\n"
                 "[protocol] tip: sudo usermod -aG bluetooth $USER and re-login"
             )
@@ -191,6 +197,8 @@ class NothingDevice(GObject.Object):
             GLib.source_remove(self._anc_debounce_id)
         self._anc_pending_mode = mode
         self._anc_debounce_id = GLib.timeout_add(300, self._do_set_anc)
+        from . import profiles
+        profiles.save(self.address, mode, self.state.eq_preset)
 
     def _do_set_anc(self):
         self._anc_debounce_id = None
@@ -210,6 +218,8 @@ class NothingDevice(GObject.Object):
             return
         eq_val = EQ_PRESETS.get(preset, 0)
         self._x55_send(_CMD_SET_EQ, bytes([eq_val]), label=f"EQ={preset}")
+        from . import profiles
+        profiles.save(self.address, self.state.anc_mode, preset)
 
     def set_in_ear_detection(self, enabled: bool):
         self.state.in_ear_detection = enabled
@@ -223,12 +233,12 @@ class NothingDevice(GObject.Object):
             services = pybluez.find_service(address=self.address)
             channels = [s["port"] for s in services if isinstance(s.get("port"), int)]
             if channels:
-                print(f"[protocol] PyBluez SDP channels: {channels}")
+                _log(f"[protocol] PyBluez SDP channels: {channels}")
                 return _prioritise(channels)
         except ImportError:
-            print("[protocol] PyBluez not installed; falling back to channel probe")
+            _log("[protocol] PyBluez not installed; falling back to channel probe")
         except Exception as exc:
-            print(f"[protocol] PyBluez SDP failed: {exc}")
+            _log(f"[protocol] PyBluez SDP failed: {exc}")
 
         try:
             out = subprocess.run(
@@ -244,15 +254,15 @@ class NothingDevice(GObject.Object):
                     except ValueError:
                         pass
             if channels:
-                print(f"[protocol] sdptool channels: {channels}")
+                _log(f"[protocol] sdptool channels: {channels}")
                 return _prioritise(channels)
-            print("[protocol] sdptool returned no channels")
+            _log("[protocol] sdptool returned no channels")
         except FileNotFoundError:
-            print("[protocol] sdptool not found; install bluez-utils or python-pybluez")
+            _log("[protocol] sdptool not found; install bluez-utils or python-pybluez")
         except Exception as exc:
-            print(f"[protocol] sdptool failed: {exc}")
+            _log(f"[protocol] sdptool failed: {exc}")
 
-        print(f"[protocol] probing channels {_PROBE_CHANNELS}")
+        _log(f"[protocol] probing channels {_PROBE_CHANNELS}")
         return _PROBE_CHANNELS
 
     def _try_channel(self, ch: int) -> tuple[socket.socket, bytes] | None:
@@ -267,11 +277,11 @@ class NothingDevice(GObject.Object):
             except OSError as exc:
                 import errno as _errno
                 if exc.errno == _errno.EBUSY and attempt == 0:
-                    print(f"[protocol] ch{ch}: busy — waiting 3s for stale connection to release")
+                    _log(f"[protocol] ch{ch}: busy — waiting 3s for stale connection to release")
                     sock.close()
                     time.sleep(3)
                     continue
-                print(f"[protocol] ch{ch}: connect failed: {exc}")
+                _log(f"[protocol] ch{ch}: connect failed: {exc}")
                 return None
         else:
             return None
@@ -301,13 +311,13 @@ class NothingDevice(GObject.Object):
             pass
 
         if not data:
-            print(f"[protocol] ch{ch}: no response (skipping)")
+            _log(f"[protocol] ch{ch}: no response (skipping)")
             sock.close()
             return None
 
         proto = "0x55" if data[0] == _SOF else (
                 "0x03-legacy" if data[0] == _L_DEV_HDR else f"0x{data[0]:02x}")
-        print(f"[protocol] ch{ch}: {proto} — {data.hex()}")
+        _log(f"[protocol] ch{ch}: {proto} — {data.hex()}")
         sock.settimeout(6)
         return sock, data
 
@@ -323,7 +333,7 @@ class NothingDevice(GObject.Object):
                 if not chunk:
                     break
                 if _DEBUG:
-                    print(f"[RX RAW] {chunk.hex()}")
+                    _log(f"[RX RAW] {chunk.hex()}")
                 buf += chunk
                 buf = self._process_buf(buf)
             except socket.timeout:
@@ -355,13 +365,13 @@ class NothingDevice(GObject.Object):
         header = struct.pack("<BHHH", _SOF, _CTRL_HOST_CRC, cmd_id, len(payload)) + bytes([self._fsn])
         frame = header + payload + struct.pack("<H", _crc16(header + payload))
         desc = f" ({label})" if label else f" {payload.hex()}" if payload else ""
-        print(f"[TX] cmd=0x{cmd_id:04X}{desc}")
+        _log(f"[TX] cmd=0x{cmd_id:04X}{desc}")
         if _DEBUG:
-            print(f"[TX RAW] {frame.hex()}")
+            _log(f"[TX RAW] {frame.hex()}")
         try:
             self._sock.sendall(frame)
         except OSError as exc:
-            print(f"[TX ERR] {exc}")
+            _log(f"[TX ERR] {exc}")
             self._handle_disconnect()
 
     def _process_x55(self, buf: bytes) -> bytes:
@@ -378,7 +388,7 @@ class NothingDevice(GObject.Object):
                 rx_crc = struct.unpack_from("<H", buf, 8 + length)[0]
                 ok_crc = _crc16(buf[:8 + length])
                 if rx_crc != ok_crc:
-                    print(f"[RX CRC ERR] got 0x{rx_crc:04X} expected 0x{ok_crc:04X}")
+                    _log(f"[RX CRC ERR] got 0x{rx_crc:04X} expected 0x{ok_crc:04X}")
             payload = buf[8:8 + length]
             cmd_id = cmd_raw | 0x8000   # normalize response→request ID
             self._dispatch_x55(cmd_id, payload)
@@ -389,12 +399,14 @@ class NothingDevice(GObject.Object):
         changed = False
         if cmd_id == _CMD_PROTO_VERSION:
             ver = payload.decode(errors="replace").strip()
-            print(f"[RX INFO] proto version={ver!r}")
+            _log(f"[RX INFO] proto version={ver!r}")
             self._x55_send(_CMD_SET_ACTIVATED)
             GLib.timeout_add(3000, self._activation_fallback)
         elif cmd_id == _CMD_SET_ACTIVATED:
-            print(f"[RX INFO] activation ACK payload={payload.hex()}")
+            _log(f"[RX INFO] activation ACK payload={payload.hex()}")
             self._activated = True
+            from . import profiles
+            profiles.set_last_device(self.address)
             # Always resend on real ACK — fallback may have sent queries before
             # the device finished activating and silently dropped them.
             self._x55_send(_CMD_BATTERY)
@@ -402,6 +414,7 @@ class NothingDevice(GObject.Object):
             self._x55_send(_CMD_EARPHONE)
             self._x55_send(_CMD_HOST_VERSION)
             self._x55_send(_CMD_REMOTE_CONF)
+            self._restore_profile()
         elif cmd_id in (_CMD_BATTERY, _EVT_BATTERY):
             changed = self._parse_battery(payload)
         elif cmd_id in (_CMD_NOISE_RED, _EVT_NOISE_RED):
@@ -412,20 +425,20 @@ class NothingDevice(GObject.Object):
             ver = payload.decode(errors="replace").strip("\x00").strip()
             if ver and ver != self.state.firmware_version:
                 self.state.firmware_version = ver
-                print(f"[protocol] firmware={ver!r}")
+                _log(f"[protocol] firmware={ver!r}")
                 changed = True
         elif cmd_id == _CMD_REMOTE_CONF:
             sn = payload.decode(errors="replace").strip("\x00").strip()
             if sn and sn != self.state.serial_number:
                 self.state.serial_number = sn
-                print(f"[protocol] serial={sn!r}")
+                _log(f"[protocol] serial={sn!r}")
                 changed = True
         elif cmd_id == _CMD_SET_NOISE_RED:
-            print(f"[RX INFO] ANC set ACK: {payload.hex()}")
+            _log(f"[RX INFO] ANC set ACK: {payload.hex()}")
         elif cmd_id == _CMD_SET_EQ:
-            print(f"[RX INFO] EQ set ACK: {payload.hex()}")
+            _log(f"[RX INFO] EQ set ACK: {payload.hex()}")
         else:
-            print(f"[RX    ] cmd=0x{cmd_id:04X} payload={payload.hex()}")
+            _log(f"[RX    ] cmd=0x{cmd_id:04X} payload={payload.hex()}")
         if changed:
             GLib.idle_add(self.emit, "state-changed")
 
@@ -455,7 +468,7 @@ class NothingDevice(GObject.Object):
                 self._check_low_battery("case", pct, "Case")
                 changed = True
         if changed:
-            print(f"[protocol] battery L={self.state.left_battery}% "
+            _log(f"[protocol] battery L={self.state.left_battery}% "
                   f"R={self.state.right_battery}% C={self.state.case_battery}%")
         return changed
 
@@ -476,7 +489,7 @@ class NothingDevice(GObject.Object):
                     mode = ANCMode.NOISE_CANCELLATION
                 if mode != self.state.anc_mode:
                     self.state.anc_mode = mode
-                    print(f"[protocol] ANC mode → {ANCMode.LABELS.get(mode, mode)} (wire val {val})")
+                    _log(f"[protocol] ANC mode → {ANCMode.LABELS.get(mode, mode)} (wire val {val})")
                     changed = True
             elif t == 2 and 1 <= val <= 4:  # NOISE_REDUCTION_LEVEL (ANC strength 1–4)
                 self._last_anc_level = val
@@ -505,7 +518,7 @@ class NothingDevice(GObject.Object):
                 self.state.right_wearing = wearing
                 changed = True
         if changed:
-            print(f"[protocol] wearing L={self.state.left_wearing} R={self.state.right_wearing}")
+            _log(f"[protocol] wearing L={self.state.left_wearing} R={self.state.right_wearing}")
         return changed
 
     # ── Legacy 0x03 frame handling (status-only fallback) ────────────────────
@@ -528,14 +541,14 @@ class NothingDevice(GObject.Object):
             self.state.right_battery = payload[1] if payload[1] <= 100 else -1
             self.state.case_battery  = (payload[2] if len(payload) >= 3
                                         and payload[2] <= 100 else -1)
-            print(f"[protocol] legacy battery L={self.state.left_battery}% "
+            _log(f"[protocol] legacy battery L={self.state.left_battery}% "
                   f"R={self.state.right_battery}% C={self.state.case_battery}%")
             self._check_low_battery("left",  self.state.left_battery,  "Left earbud")
             self._check_low_battery("right", self.state.right_battery, "Right earbud")
             self._check_low_battery("case",  self.state.case_battery,  "Case")
             GLib.idle_add(self.emit, "state-changed")
         elif msg_type == _L_INIT and payload:
-            print(f"[protocol] legacy init: {payload.hex()} — echoing back")
+            _log(f"[protocol] legacy init: {payload.hex()} — echoing back")
             # Echo init to complete handshake
             frame = bytes([_L_HOST_HDR, _L_INIT]) + struct.pack(">H", len(payload)) + payload
             try:
@@ -544,11 +557,26 @@ class NothingDevice(GObject.Object):
             except OSError:
                 pass
         elif msg_type == _L_STATE and payload:
-            print(f"[protocol] legacy state: {payload.hex()}")
+            _log(f"[protocol] legacy state: {payload.hex()}")
         else:
-            print(f"[protocol] legacy type=0x{msg_type:02x} payload={payload.hex()}")
+            _log(f"[protocol] legacy type=0x{msg_type:02x} payload={payload.hex()}")
 
     # ── Utilities ─────────────────────────────────────────────────────────────
+
+    def _restore_profile(self):
+        from . import profiles
+        p = profiles.load(self.address)
+        if not p:
+            return
+        if "anc" in p:
+            anc = p["anc"]
+            wire = (_ANC_TRANSPARENCY if anc == ANCMode.TRANSPARENCY
+                    else _ANC_OFF if anc == ANCMode.OFF else _ANC_STRONG)
+            self._x55_send(_CMD_SET_NOISE_RED, bytes([0x01, wire, 0x00]),
+                           label=f"restore ANC={ANCMode.LABELS.get(anc)}")
+        if "eq" in p:
+            eq_val = EQ_PRESETS.get(p["eq"], 0)
+            self._x55_send(_CMD_SET_EQ, bytes([eq_val]), label=f"restore EQ={p['eq']}")
 
     def _check_low_battery(self, slot: str, pct: int, label: str):
         if pct < 0:
@@ -567,7 +595,7 @@ class NothingDevice(GObject.Object):
 
     def _activation_fallback(self):
         if not self._activated and self._rfcomm_connected:
-            print("[protocol] activation ACK not received within 3s — sending GET queries")
+            _log("[protocol] activation ACK not received within 3s — sending GET queries")
             self._activated = True
             self._x55_send(_CMD_BATTERY)
             self._x55_send(_CMD_NOISE_RED, bytes([0x03]))

--- a/nothing_app/splash.py
+++ b/nothing_app/splash.py
@@ -150,7 +150,7 @@ class SplashScreen(Adw.Window):
             advances = [cr.text_extents(ch).x_advance for ch in sub]
             total_w = sum(advances) + spacing * (len(sub) - 1)
             lx = cx - total_w / 2
-            for ch, adv in zip(sub, advances):
+            for ch, adv in zip(sub, advances, strict=True):
                 te = cr.text_extents(ch)
                 cr.set_source_rgba(1.0, 1.0, 1.0, 0.32 * sub_p)
                 cr.move_to(lx - te.x_bearing, sub_y)

--- a/nothing_app/splash.py
+++ b/nothing_app/splash.py
@@ -2,6 +2,7 @@ import math
 import time
 import cairo
 import gi
+
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw, GLib

--- a/nothing_app/window.py
+++ b/nothing_app/window.py
@@ -1,4 +1,5 @@
 import gi
+
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw
@@ -75,6 +76,7 @@ class SomethingXWindow(Adw.ApplicationWindow):
 
     def _open_bt_settings(self, _btn):
         import subprocess
+
         for cmd in (
             ["blueman-manager"],
             ["gnome-control-center", "bluetooth"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,16 @@ include = ["nothing_app*"]
 
 [tool.setuptools.package-data]
 nothing_app = ["data/*.css", "data/*.desktop"]
+
+[project.optional-dependencies]
+dev = ["ruff"]
+
+[tool.ruff]
+line-length = 110
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B"]
+ignore = [
+    "E402",  # module-level import not at top — required by gi.require_version() pattern
+    "I001",  # import sort — same reason
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "something-x"
-version = "1.2.1"
+version = "1.2.2"
 description     = "Something X device manager for Omarchy / Linux"
 readme          = "README.md"
 license         = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "something-x"
-version = "1.2.2"
+version = "1.2.3"
 description     = "Something X device manager for Omarchy / Linux"
 readme          = "README.md"
 license         = { text = "MIT" }


### PR DESCRIPTION
##Summary

Per-device profiles : ANC mode and EQ preset are saved per device address to ~/.config/something-x/profiles.json on every change and restored automatically by sending SET commands to the device after RFCOMM activation. The last connected device address is also persisted for CLI use.

Background mode : closing the window hides it instead of quitting. Running something-x again re-shows the existing window via Gio single-instance handling, with a notify-send informing the user the app is still running.

CLI quick-toggles : headless RFCOMM mode activated when any of --battery, --anc, --eq are passed. Protocol output is suppressed in CLI mode. Combines with --device AA:BB:CC:DD:EE:FF to target a specific device.


something-x --battery
something-x --anc off|on|transparency
something-x --eq balanced|bass|treble|voice
something-x --anc on --eq bass
Code quality — ruff configured in pyproject.toml (rules E/F/W/I/UP/B, line-length 110). CI workflow runs on every PR: reviewdog posts inline review comments on the diff for each finding, and ruff format --check blocks merge if formatting is wrong. Pre-existing lint issues fixed (unused imports, socket.timeout alias, zip without strict=).