### PR TITLE
feat: SNI system tray icon with battery tooltip and device-type icons

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ The RFCOMM `0x55` protocol is shared across the entire Nothing Ear lineup. Confi
 - [x] **Background mode** — closing the window hides it; relaunch shows it again (Gio single-instance)
 - [x] **Per-device profiles** — ANC + EQ saved per device address to `~/.config/something-x/profiles.json`, restored automatically on reconnect
 - [x] **CLI quick-toggle** — `something-x --anc off|on|transparency`, `something-x --eq bass`, `something-x --battery`
-- [ ] **System tray icon** — show battery on hover via StatusNotifierItem (Waybar/SNI)
+- [x] **System tray icon** — show battery on hover via StatusNotifierItem (Waybar/SNI)
 - [ ] **Wearing detection display** — show L/R in-ear status on the earbud visual
 - [x] **Auto-connect RFCOMM** — connect as soon as BlueZ reports the device connected, no tap needed
 

--- a/nothing_app/application.py
+++ b/nothing_app/application.py
@@ -13,6 +13,7 @@ from gi.repository import Gtk, Adw, Gdk, Gio, GLib
 from .bluetooth import BluetoothManager
 from .window import SomethingXWindow
 from .splash import SplashScreen
+from .tray import SomethingXTray
 
 
 def _install_desktop_file():
@@ -50,6 +51,7 @@ class SomethingXApplication(Adw.Application):
         self._bt: BluetoothManager | None = None
         self._splash: SplashScreen | None = None
         self._window: SomethingXWindow | None = None
+        self._tray: SomethingXTray | None = None
         self.connect("activate", self._on_activate)
 
     def _on_activate(self, _app):
@@ -72,6 +74,7 @@ class SomethingXApplication(Adw.Application):
         win = SomethingXWindow(bt_manager=self._bt, application=self)
         win.connect("close-request", self._on_window_close)
         self._window = win
+        self._tray = SomethingXTray(self._bt, on_show_window=win.present)
         win.present()
         if self._splash:
             self._splash.destroy()

--- a/nothing_app/bluetooth.py
+++ b/nothing_app/bluetooth.py
@@ -44,6 +44,40 @@ class BluetoothDevice:
         return f"<BTDevice {self.name!r} {'●' if self.connected else '○'}>"
 
 
+# BlueZ Device1.Icon → GTK symbolic icon name
+_BLUEZ_ICON_MAP: dict[str, str] = {
+    "audio-headphones": "audio-headphones-symbolic",
+    "audio-headset": "audio-headset-symbolic",
+    "audio-card": "audio-card-symbolic",
+    "input-mouse": "input-mouse-symbolic",
+    "input-keyboard": "input-keyboard-symbolic",
+    "input-gaming": "input-gaming-symbolic",
+    "input-tablet": "input-tablet-symbolic",
+    "phone": "phone-symbolic",
+    "computer": "computer-symbolic",
+    "printer": "printer-symbolic",
+}
+
+_WATCH_NAME_PATTERNS = ("watch", "band", "gear", "amazfit", "fenix", "vivoactive", "galaxy fit")
+
+
+def device_icon_name(device: "BluetoothDevice | None") -> str:
+    """Return a GTK symbolic icon name for a Bluetooth device."""
+    if device is None:
+        return "audio-headphones-symbolic"
+    name_lower = device.name.lower()
+    if any(p in name_lower for p in _WATCH_NAME_PATTERNS):
+        return "alarm-symbolic"
+    if "ear (stick)" in name_lower:
+        return "audio-input-microphone-symbolic"
+    mapped = _BLUEZ_ICON_MAP.get(device.icon)
+    if mapped:
+        return mapped
+    if "phone" in name_lower:
+        return "phone-symbolic"
+    return "audio-headphones-symbolic"
+
+
 class BluetoothManager(GObject.Object):
     __gsignals__ = {
         "devices-changed": (GObject.SignalFlags.RUN_FIRST, None, ()),

--- a/nothing_app/pages/device.py
+++ b/nothing_app/pages/device.py
@@ -265,7 +265,12 @@ def _settings_row(title: str, subtitle: str = "", right_widget: Gtk.Widget | Non
 
 
 class DevicePage(Gtk.Box):
-    def __init__(self, bt_device: BluetoothDevice, bt_manager: BluetoothManager, nothing_dev: NothingDevice | None = None):
+    def __init__(
+        self,
+        bt_device: BluetoothDevice,
+        bt_manager: BluetoothManager,
+        nothing_dev: NothingDevice | None = None,
+    ):
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self._bt_device = bt_device
         self._bt = bt_manager

--- a/nothing_app/pages/home.py
+++ b/nothing_app/pages/home.py
@@ -3,7 +3,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, GLib, GObject
 
-from ..bluetooth import BluetoothDevice, BluetoothManager
+from ..bluetooth import BluetoothDevice, BluetoothManager, device_icon_name
 
 
 class DeviceRow(Gtk.Box):
@@ -14,12 +14,7 @@ class DeviceRow(Gtk.Box):
         self._build()
 
     def _build(self):
-        icon_name = "audio-headphones-symbolic"
-        if "phone" in self.device.name.lower():
-            icon_name = "phone-symbolic"
-        elif "ear (stick)" in self.device.name.lower():
-            icon_name = "audio-input-microphone-symbolic"
-        icon = Gtk.Image.new_from_icon_name(icon_name)
+        icon = Gtk.Image.new_from_icon_name(device_icon_name(self.device))
         icon.set_pixel_size(28)
         icon.set_opacity(0.6)
         self.append(icon)

--- a/nothing_app/tray.py
+++ b/nothing_app/tray.py
@@ -1,0 +1,149 @@
+import os
+import dbus
+import dbus.service
+from gi.repository import GLib, GObject
+
+from .bluetooth import BluetoothManager, BluetoothDevice, device_icon_name
+
+_ITEM_IFACE = "org.kde.StatusNotifierItem"
+_WATCHER_IFACE = "org.kde.StatusNotifierWatcher"
+_WATCHER_SERVICE = "org.kde.StatusNotifierWatcher"
+_ITEM_PATH = "/StatusNotifierItem"
+
+_EMPTY_PIXMAPS = dbus.Array([], signature="(iiay)")
+
+
+class _SNIItem(dbus.service.Object):
+    def __init__(self, bus, service_name, on_activate):
+        bus_name = dbus.service.BusName(service_name, bus)
+        super().__init__(bus_name, _ITEM_PATH)
+        self._on_activate = on_activate
+        self._icon_name = "audio-headphones"
+        self._tooltip_title = "Something X"
+        self._tooltip_body = ""
+
+    # ── SNI methods ────────────────────────────────────────────────────────────
+
+    @dbus.service.method(_ITEM_IFACE, in_signature="ii")
+    def Activate(self, x, y):
+        GLib.idle_add(self._on_activate)
+
+    @dbus.service.method(_ITEM_IFACE, in_signature="ii")
+    def SecondaryActivate(self, x, y):
+        pass
+
+    @dbus.service.method(_ITEM_IFACE, in_signature="ii")
+    def ContextMenu(self, x, y):
+        pass
+
+    @dbus.service.method(_ITEM_IFACE, in_signature="is")
+    def Scroll(self, delta, orientation):
+        pass
+
+    # ── SNI signals ───────────────────────────────────────────────────────────
+
+    @dbus.service.signal(_ITEM_IFACE)
+    def NewIcon(self):
+        pass
+
+    @dbus.service.signal(_ITEM_IFACE)
+    def NewToolTip(self):
+        pass
+
+    @dbus.service.signal(_ITEM_IFACE, signature="s")
+    def NewStatus(self, status):
+        pass
+
+    # ── D-Bus Properties ──────────────────────────────────────────────────────
+
+    @dbus.service.method(dbus.PROPERTIES_IFACE, in_signature="ss", out_signature="v")
+    def Get(self, interface, prop):
+        return self._props()[prop]
+
+    @dbus.service.method(dbus.PROPERTIES_IFACE, in_signature="s", out_signature="a{sv}")
+    def GetAll(self, interface):
+        return self._props()
+
+    def _props(self):
+        tooltip = dbus.Struct(
+            (
+                dbus.String(""),
+                _EMPTY_PIXMAPS,
+                dbus.String(self._tooltip_title),
+                dbus.String(self._tooltip_body),
+            ),
+            signature="sa(iiay)ss",
+        )
+        return {
+            "Id": dbus.String("something-x"),
+            "Category": dbus.String("Hardware"),
+            "Title": dbus.String("Something X"),
+            "Status": dbus.String("Active"),
+            "WindowId": dbus.UInt32(0),
+            "IconName": dbus.String(self._icon_name),
+            "IconPixmap": _EMPTY_PIXMAPS,
+            "OverlayIconName": dbus.String(""),
+            "OverlayIconPixmap": _EMPTY_PIXMAPS,
+            "AttentionIconName": dbus.String(""),
+            "AttentionIconPixmap": _EMPTY_PIXMAPS,
+            "AttentionMovieName": dbus.String(""),
+            "ToolTip": tooltip,
+            "ItemIsMenu": dbus.Boolean(False),
+            "Menu": dbus.ObjectPath(_ITEM_PATH),
+        }
+
+    # ── update helpers ────────────────────────────────────────────────────────
+
+    def set_icon(self, icon_name: str):
+        if icon_name != self._icon_name:
+            self._icon_name = icon_name
+            self.NewIcon()
+
+    def set_tooltip(self, title: str, body: str):
+        self._tooltip_title = title
+        self._tooltip_body = body
+        self.NewToolTip()
+
+
+class SomethingXTray(GObject.Object):
+    """StatusNotifierItem tray icon. Shows battery on hover; icon adapts to device type."""
+
+    def __init__(self, bt_manager: BluetoothManager, on_show_window):
+        super().__init__()
+        self._bt = bt_manager
+        self._on_show = on_show_window
+        self._item: _SNIItem | None = None
+        self._setup()
+        bt_manager.connect("devices-changed", self._on_devices_changed)
+
+    def _setup(self):
+        try:
+            bus = dbus.SessionBus()
+            service_name = f"org.kde.StatusNotifierItem-{os.getpid()}-1"
+            self._item = _SNIItem(bus, service_name, self._on_show)
+            try:
+                watcher = bus.get_object(_WATCHER_SERVICE, "/StatusNotifierWatcher")
+                dbus.Interface(watcher, _WATCHER_IFACE).RegisterStatusNotifierItem(service_name)
+            except dbus.exceptions.DBusException:
+                pass  # watcher not running; item is still exported on the bus
+        except Exception as exc:
+            print(f"[tray] SNI setup failed: {exc}")
+
+    def _on_devices_changed(self, _manager):
+        if not self._item:
+            return
+        nothing_devs = self._bt.get_nothing_devices()
+        connected = [d for d in nothing_devs if d.connected]
+        if connected:
+            dev = connected[0]
+            parts = []
+            if dev.battery is not None:
+                parts.append(f"{dev.name}: {dev.battery}%")
+            self._item.set_tooltip("Something X", "\n".join(parts) if parts else "Connected")
+            self._item.set_icon(device_icon_name(dev))
+        else:
+            # fall back to first paired Nothing device, or generic icon
+            paired = nothing_devs[0] if nothing_devs else None
+            icon = device_icon_name(paired) if paired else "audio-headphones"
+            self._item.set_tooltip("Something X", "No devices connected")
+            self._item.set_icon(icon)


### PR DESCRIPTION
Adds a StatusNotifierItem tray icon (Waybar/KDE/SNI-compatible):
- Left-click shows the main window
- Tooltip shows battery % of connected Nothing device
- Icon adapts to device type (earbuds, mouse, keyboard, watch, phone) using the BlueZ Device1.Icon property via a new device_icon_name() helper in bluetooth.py
- Home page DeviceRow now uses the same helper for consistent icons across mice, keyboards, watches, and other non-earbud devices