### PR TITLE
feat: async Gio D-Bus + unit test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,13 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-4.0 libgirepository1.0-dev
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      # Use a venv that inherits system site-packages so apt-installed gi is visible.
+      # PyGObject cannot be pip-built without Cairo/GLib headers; use the distro package.
+      - name: Create venv with system site-packages
+        run: python3 -m venv --system-site-packages .venv
 
-      - name: Install Python dependencies
-        run: pip install pytest pytest-cov PyGObject
+      - name: Install test dependencies
+        run: .venv/bin/pip install pytest pytest-cov
 
       - name: Run tests
-        run: pytest --tb=short --cov=nothing_app --cov-report=term-missing
+        run: .venv/bin/pytest --tb=short --cov=nothing_app --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,25 @@ jobs:
       # Still fail the job if formatting is wrong
       - name: Check formatting
         run: ruff format --check nothing_app/
+
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-4.0 libgirepository1.0-dev
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: pip install pytest pytest-cov PyGObject
+
+      - name: Run tests
+        run: pytest --tb=short --cov=nothing_app --cov-report=term-missing

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -30,9 +30,9 @@ jobs:
           DEV_VERSION="${CURRENT}.dev${{ github.run_number }}"
           SHORT_SHA=$(git rev-parse --short HEAD)
 
-          echo "current=$CURRENT"       >> $GITHUB_OUTPUT
+          echo "current=$CURRENT"         >> $GITHUB_OUTPUT
           echo "dev_version=$DEV_VERSION" >> $GITHUB_OUTPUT
-          echo "short_sha=$SHORT_SHA"   >> $GITHUB_OUTPUT
+          echo "short_sha=$SHORT_SHA"     >> $GITHUB_OUTPUT
           echo "Dev version: $DEV_VERSION (sha: $SHORT_SHA)"
 
       # ── Patch pyproject.toml for dev build ──────────────────────────────
@@ -55,29 +55,50 @@ jobs:
           python -m build
           ls dist/
 
+      # ── Generate changelog with git-cliff ──────────────────────────────
+      - name: Install git-cliff
+        run: pip install git-cliff
+
+      - name: Generate pre-release notes
+        run: |
+          # --unreleased: all conventional commits since the last vX.Y.Z tag
+          # cliff.toml: skips merge commits, ignores dev-* tags
+          git cliff --unreleased --strip all 2>/dev/null > /tmp/cliff_body.md
+          if [ ! -s /tmp/cliff_body.md ]; then
+            echo "No user-facing changes since last release." > /tmp/cliff_body.md
+          fi
+
+          cat > /tmp/release_notes.md <<HEADER
+          ## something-x-dev ${{ steps.version.outputs.dev_version }}
+
+          > Pre-release build from \`develop\` — not for production use.
+
+          **Commit**: \`${{ steps.version.outputs.short_sha }}\`
+
+          ### Changes since last stable release
+
+          HEADER
+          cat /tmp/cliff_body.md >> /tmp/release_notes.md
+          cat >> /tmp/release_notes.md <<'FOOTER'
+
+          ### Install
+
+          ```bash
+          pip install something-x-dev==${{ steps.version.outputs.dev_version }}
+
+          # Or download the wheel below
+          pip install something_x_dev-${{ steps.version.outputs.dev_version }}-py3-none-any.whl
+          ```
+          FOOTER
+
       # ── GitHub pre-release ──────────────────────────────────────────────
       - name: Create GitHub pre-release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: "dev-${{ steps.version.outputs.short_sha }}"
           prerelease: true
-          generate_release_notes: true
+          body_path: /tmp/release_notes.md
           files: dist/*
-          body: |
-            ## something-x-dev ${{ steps.version.outputs.dev_version }}
-
-            > Pre-release build from `develop` — not for production use.
-
-            **Commit**: `${{ steps.version.outputs.short_sha }}`
-
-            ### Install
-
-            ```bash
-            pip install something-x-dev==${{ steps.version.outputs.dev_version }}
-
-            # Or download the wheel below
-            pip install something_x_dev-${{ steps.version.outputs.dev_version }}-py3-none-any.whl
-            ```
 
       # ── Publish to PyPI (OIDC — requires trusted publisher configured) ──
       - name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Skip if the commit was made by the bot itself (version bump commit)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     steps:
@@ -38,19 +37,15 @@ jobs:
           MINOR=$(echo $CURRENT | cut -d. -f2)
           PATCH=$(echo $CURRENT | cut -d. -f3)
 
-          # MAJOR: breaking change marker
           if echo "$COMMIT_MSG" | grep -qE "(^(feat|fix|refactor|perf)!:)|(BREAKING CHANGE:)"; then
             BUMP=major
             MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
-          # MINOR: new feature
           elif echo "$COMMIT_MSG" | grep -qE "^feat(\([^)]+\))?:"; then
             BUMP=minor
             MINOR=$((MINOR + 1)); PATCH=0
-          # PATCH: bug fix or improvement
           elif echo "$COMMIT_MSG" | grep -qE "^(fix|perf|refactor)(\([^)]+\))?:"; then
             BUMP=patch
             PATCH=$((PATCH + 1))
-          # No release: maintenance commits
           else
             echo "Commit type does not trigger a release (docs/chore/style/ci/test). Skipping."
             echo "skip=true" >> $GITHUB_OUTPUT
@@ -83,6 +78,44 @@ jobs:
           git push origin main
           git push origin "v${{ steps.version.outputs.new }}"
 
+      # ── Generate changelog with git-cliff ──────────────────────────────
+      - name: Install git-cliff
+        if: steps.version.outputs.skip != 'true'
+        run: pip install git-cliff
+
+      - name: Generate release notes
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          # --latest: commits from the previous vX.Y.Z tag up to the tag we just pushed
+          # cliff.toml: skips merge commits, ignores dev-* tags, filters to conventional commits
+          git cliff --latest --strip all 2>/dev/null > /tmp/cliff_body.md
+          if [ ! -s /tmp/cliff_body.md ]; then
+            echo "No user-facing changes in this release." > /tmp/cliff_body.md
+          fi
+
+          # Prepend the header + install block; cliff body goes in the middle
+          cat > /tmp/release_notes.md <<HEADER
+          ## Something X v${{ steps.version.outputs.new }}
+
+          HEADER
+          cat /tmp/cliff_body.md >> /tmp/release_notes.md
+          cat >> /tmp/release_notes.md <<'FOOTER'
+
+          ### Install
+
+          ```bash
+          # Arch / Omarchy (recommended)
+          sudo pacman -S python-gobject python-dbus python-cairo gtk4 libadwaita
+          pip install something-x==${{ steps.version.outputs.new }}
+
+          # Or download the wheel below
+          pip install something_x-${{ steps.version.outputs.new }}-py3-none-any.whl
+          ```
+          FOOTER
+
+          echo "--- Release notes preview ---"
+          cat /tmp/release_notes.md
+
       # ── Build wheel + sdist ─────────────────────────────────────────────
       - name: Set up Python
         if: steps.version.outputs.skip != 'true'
@@ -103,25 +136,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: "v${{ steps.version.outputs.new }}"
-          generate_release_notes: true
+          body_path: /tmp/release_notes.md
           files: dist/*
-          body: |
-            ## Something X v${{ steps.version.outputs.new }}
 
-            **Bump type**: `${{ steps.version.outputs.bump }}`
-
-            ### Install
-
-            ```bash
-            # Arch / Omarchy (recommended)
-            sudo pacman -S python-gobject python-dbus python-cairo gtk4 libadwaita
-            pip install something-x==${{ steps.version.outputs.new }}
-
-            # Or download the wheel below and install directly
-            pip install something_x-${{ steps.version.outputs.new }}-py3-none-any.whl
-            ```
-
-      # ── Publish to PyPI (OIDC trusted publisher — no secret needed) ─────
+      # ── Publish to PyPI (OIDC trusted publisher) ────────────────────────
       - name: Publish to PyPI
         if: steps.version.outputs.skip != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -133,8 +151,6 @@ jobs:
           NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
           SHA256=$(sha256sum dist/something_x-${NEW_VERSION}.tar.gz | awk '{print $1}')
-          echo "sha256: $SHA256"
-
           sed -i "s/^pkgver=.*/pkgver=${NEW_VERSION}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
           sed -i "s/sha256sums=('[^']*')/sha256sums=('${SHA256}')/" PKGBUILD

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Built for [Omarchy](https://omarchy.org) · GTK4 · Pure black · JetBrains Mono
 [![AUR](https://img.shields.io/aur/version/something-x?color=red)](https://aur.archlinux.org/packages/something-x)
 [![License: MIT](https://img.shields.io/badge/license-MIT-red.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Linux-lightgrey)](https://github.com/SoaOaoS/something-x)
+[![CI](https://github.com/SoaOaoS/something-x/actions/workflows/ci.yml/badge.svg)](https://github.com/SoaOaoS/something-x/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-tracked-red)](https://github.com/SoaOaoS/something-x/actions/workflows/ci.yml)
 
 </div>
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,41 @@
+[changelog]
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group }}
+{% for commit in commits | sort(attribute="message") %}
+- {% if commit.scope %}**{{ commit.scope }}**: {% endif %}\
+{{ commit.message | upper_first }}\
+{% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat",     group = "Features" },
+  { message = "^fix",      group = "Bug Fixes" },
+  { message = "^perf",     group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^docs",     group = "Documentation" },
+  { message = "^style",    group = "Styling" },
+  { message = "^test",     group = "Testing" },
+  # skip anything that isn't useful in a user-facing changelog
+  { message = "^chore: release", skip = true },
+  { message = "^chore",    skip = true },
+  { message = "^ci",       skip = true },
+  { message = "^build",    skip = true },
+  # skip all merge commits regardless of how they are worded
+  { message = "^[Mm]erge[ /]", skip = true },
+  { message = "^Merged",       skip = true },
+]
+filter_commits = false
+# semver release tags only; dev-* tags are ignored for "previous release" calculation
+tag_pattern  = "v[0-9]+\\.[0-9]+\\.[0-9]+"
+ignore_tags  = "dev-.*"
+topo_order   = false
+sort_commits = "oldest"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,192 @@
+# Release Management Guide
+
+## The problem this setup solves
+
+The old setup used GitHub's `generate_release_notes: true`, which lists every merged PR.
+Because feature branches were merged (not squash-merged) into `develop`, each feature
+appeared **twice** in the release notes:
+
+1. As the original commit from the feature branch (included transitively through develop→main)
+2. As the merge commit of the PR (directly listed by GitHub's generator)
+
+This guide explains the correct workflow and how the new tooling (`git-cliff`) fixes it.
+
+---
+
+## How it works now
+
+### Tools
+
+- **[git-cliff](https://git-cliff.org/)** — reads your git log, keeps only conventional commits,
+  skips all merge commits, ignores `dev-*` tags, and groups changes by type.
+- **`cliff.toml`** (repo root) — configuration for the above.
+
+### Workflows
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `release-dev.yml` | push to `develop` | builds `something-x-dev`, publishes pre-release + PyPI dev |
+| `release.yml` | push to `main` | bumps semver, tags, builds `something-x`, publishes release + PyPI + AUR |
+
+---
+
+## The only rule: **squash-merge feature branches into develop**
+
+This is what prevents duplicate entries. When you squash-merge a feature PR into `develop`:
+
+- The feature branch's original commits are **not** added to `develop`'s ancestry.
+- A single clean conventional commit lands in `develop`.
+- When `develop` is merged into `main`, that single commit appears **once** in `main`'s history.
+- `git-cliff` reads it **once** → no duplicates.
+
+If you use a regular merge instead of squash, the original feature commits enter `develop`'s
+history and will appear in the changelog alongside the squash commit.
+
+### Merge strategy by branch target
+
+| PR target | Merge strategy | Why |
+|---|---|---|
+| `develop` | **Squash and merge** | one commit per feature, no duplicates |
+| `main` (from `develop`) | **Create a merge commit** | preserves individual squashed commits from develop |
+
+### How to enforce this in GitHub
+
+1. Go to **Settings → General → Pull Requests**
+2. Under "Allow merge commits": **✓ (keep enabled)** — needed for develop→main
+3. Under "Allow squash merging": **✓ (keep enabled)**
+4. Under "Allow rebase merging": uncheck (optional, avoids confusion)
+5. You cannot enforce squash-only per target branch in vanilla GitHub — rely on convention
+   and PR review. The commit history makes violations obvious immediately.
+
+---
+
+## Day-to-day workflow
+
+```
+feat/my-feature  ──squash──▶  develop  ──merge commit──▶  main
+                                  │                          │
+                            pre-release tag             release tag
+                           (dev-<sha>)                  (v1.2.3)
+```
+
+### 1. Develop a feature
+
+```bash
+git checkout develop
+git checkout -b feat/my-feature
+# ... work ...
+git push origin feat/my-feature
+```
+
+Open a PR from `feat/my-feature` → `develop`.  
+Use **"Squash and merge"** when merging. Write a conventional commit message:
+
+```
+feat: add ANC mode detection for CMF Buds Pro 2
+```
+
+### 2. Ship a release
+
+Open a PR from `develop` → `main`.  
+Use **"Create a merge commit"** (default).
+
+The commit message on main that triggers the release must follow conventional commits:
+
+- `feat: ...` → bumps minor (1.6.0 → 1.7.0)
+- `fix: ...` or `refactor: ...` or `perf: ...` → bumps patch (1.6.0 → 1.6.1)
+- `feat!:` or `BREAKING CHANGE:` → bumps major (1.6.0 → 2.0.0)
+- `docs:`, `chore:`, `ci:`, `style:` → **no release triggered**
+
+The bot then:
+1. Updates `version` in `pyproject.toml`
+2. Commits `chore: release vX.Y.Z [skip ci]` and pushes the tag
+3. Runs `git-cliff --latest` to build the changelog (skips merge commits, no duplicates)
+4. Creates the GitHub release with the clean notes
+5. Publishes to PyPI and updates AUR
+
+---
+
+## Deploying this PR without breaking existing tags
+
+The existing tags (`v1.2.0` through `v1.6.0`, and the `dev-*` tags) are **untouched** by
+this PR. Here is the exact sequence to land it safely:
+
+### Step 1 — merge this branch into `main`
+
+```bash
+# On GitHub: open PR from chore/release-management → main
+# Use "Create a merge commit" (or squash — doesn't matter for a CI-only change)
+```
+
+Use a `chore:` or `ci:` commit message so the release workflow **skips** (no spurious release):
+
+```
+ci: replace generate_release_notes with git-cliff
+```
+
+The `release.yml` will see `ci:` → log "Commit type does not trigger a release. Skipping." → done.
+No new tag, no new release, existing tags are completely untouched.
+
+### Step 2 — verify the cliff config picks up history correctly
+
+After merging, run locally to preview what the next release changelog will look like:
+
+```bash
+pip install git-cliff
+git cliff v1.6.0..HEAD --strip all
+```
+
+If that output looks right, you're good. If it's empty, check that your commits since v1.6.0
+use conventional commit format (`feat:`, `fix:`, etc.).
+
+### Step 3 — first real release under the new system
+
+Work as normal (feature branches squash-merged into develop, then develop merged into main
+with a conventional commit message). The workflow fires, `git-cliff --latest` generates notes
+from `v1.6.0..v1.7.0` (or whatever the next version is), and the release notes are clean.
+
+---
+
+## Troubleshooting
+
+### "Release notes are empty"
+
+`git-cliff` with `filter_unconventional = true` silently drops non-conventional commits.
+Check your commit messages since the last `vX.Y.Z` tag:
+
+```bash
+git log v1.6.0..HEAD --oneline --no-merges
+```
+
+Any commit not starting with `feat:`, `fix:`, `refactor:`, `perf:`, `docs:`, etc. is dropped.
+
+### "I still see duplicates"
+
+Someone used regular merge (not squash) for a feature PR into develop. Find the offending
+merge commit:
+
+```bash
+git log develop --merges --oneline | head -10
+```
+
+For future PRs, remind contributors to use squash. For past ones, the duplicate is harmless —
+`git-cliff` deduplicates by hash, so if two commits have the same hash they only appear once.
+Cherry-picks (different hash, same message) can still appear twice — the fix is to never
+cherry-pick; always merge or squash-merge properly.
+
+### "The release workflow bumped the wrong version"
+
+The bump is driven by the **last commit message on main** at trigger time. If the develop→main
+merge commit has a vague message like "Merge branch develop", no release fires. Make sure the
+merge commit (or the squash commit if you squash develop→main) has a conventional message
+that reflects the highest-impact change in the batch.
+
+### "I need to re-generate release notes for an existing tag"
+
+Edit the release on GitHub manually, or delete and recreate it (the tag stays):
+
+```bash
+gh release delete v1.6.0 --yes        # deletes the release, NOT the tag
+git cliff v1.5.0..v1.6.0 --strip all  # preview the notes
+gh release create v1.6.0 --notes "$(git cliff v1.5.0..v1.6.0 --strip all)"
+```

--- a/nothing_app/bluetooth.py
+++ b/nothing_app/bluetooth.py
@@ -100,13 +100,23 @@ class BluetoothManager(GObject.Object):
         try:
             self._connection = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
             mgr = Gio.DBusProxy.new_sync(
-                self._connection, _FLAGS_METHOD, None,
-                BLUEZ_SERVICE, "/", OBJ_MANAGER_IFACE, None,
+                self._connection,
+                _FLAGS_METHOD,
+                None,
+                BLUEZ_SERVICE,
+                "/",
+                OBJ_MANAGER_IFACE,
+                None,
             )
             # Non-blocking: populates devices and emits devices-changed when ready
             mgr.call(
-                "GetManagedObjects", None, Gio.DBusCallFlags.NONE, -1, None,
-                self._on_managed_objects, None,
+                "GetManagedObjects",
+                None,
+                Gio.DBusCallFlags.NONE,
+                -1,
+                None,
+                self._on_managed_objects,
+                None,
             )
             self._subscribe()
         except Exception as exc:
@@ -140,21 +150,42 @@ class BluetoothManager(GObject.Object):
         if not self._connection:
             return
         try:
-            self._subs.append(self._connection.signal_subscribe(
-                BLUEZ_SERVICE, PROPERTIES_IFACE, "PropertiesChanged",
-                None, None, Gio.DBusSignalFlags.NONE,
-                self._on_props_changed, None,
-            ))
-            self._subs.append(self._connection.signal_subscribe(
-                BLUEZ_SERVICE, OBJ_MANAGER_IFACE, "InterfacesAdded",
-                None, None, Gio.DBusSignalFlags.NONE,
-                self._on_ifaces_added, None,
-            ))
-            self._subs.append(self._connection.signal_subscribe(
-                BLUEZ_SERVICE, OBJ_MANAGER_IFACE, "InterfacesRemoved",
-                None, None, Gio.DBusSignalFlags.NONE,
-                self._on_ifaces_removed, None,
-            ))
+            self._subs.append(
+                self._connection.signal_subscribe(
+                    BLUEZ_SERVICE,
+                    PROPERTIES_IFACE,
+                    "PropertiesChanged",
+                    None,
+                    None,
+                    Gio.DBusSignalFlags.NONE,
+                    self._on_props_changed,
+                    None,
+                )
+            )
+            self._subs.append(
+                self._connection.signal_subscribe(
+                    BLUEZ_SERVICE,
+                    OBJ_MANAGER_IFACE,
+                    "InterfacesAdded",
+                    None,
+                    None,
+                    Gio.DBusSignalFlags.NONE,
+                    self._on_ifaces_added,
+                    None,
+                )
+            )
+            self._subs.append(
+                self._connection.signal_subscribe(
+                    BLUEZ_SERVICE,
+                    OBJ_MANAGER_IFACE,
+                    "InterfacesRemoved",
+                    None,
+                    None,
+                    Gio.DBusSignalFlags.NONE,
+                    self._on_ifaces_removed,
+                    None,
+                )
+            )
         except Exception as exc:
             print(f"[bluetooth] Signal subscribe failed: {exc}")
 
@@ -206,12 +237,22 @@ class BluetoothManager(GObject.Object):
             return
         try:
             mgr = Gio.DBusProxy.new_sync(
-                self._connection, _FLAGS_METHOD, None,
-                BLUEZ_SERVICE, "/", OBJ_MANAGER_IFACE, None,
+                self._connection,
+                _FLAGS_METHOD,
+                None,
+                BLUEZ_SERVICE,
+                "/",
+                OBJ_MANAGER_IFACE,
+                None,
             )
             mgr.call(
-                "GetManagedObjects", None, Gio.DBusCallFlags.NONE, -1, None,
-                self._on_managed_objects, None,
+                "GetManagedObjects",
+                None,
+                Gio.DBusCallFlags.NONE,
+                -1,
+                None,
+                self._on_managed_objects,
+                None,
             )
         except Exception as exc:
             print(f"[bluetooth] refresh: {exc}")
@@ -220,17 +261,28 @@ class BluetoothManager(GObject.Object):
         if not self._connection:
             return
         Gio.DBusProxy.new(
-            self._connection, _FLAGS_METHOD, None,
-            BLUEZ_SERVICE, path, DEVICE_IFACE,
-            None, self._on_connect_proxy_ready, on_error,
+            self._connection,
+            _FLAGS_METHOD,
+            None,
+            BLUEZ_SERVICE,
+            path,
+            DEVICE_IFACE,
+            None,
+            self._on_connect_proxy_ready,
+            on_error,
         )
 
     def _on_connect_proxy_ready(self, _source, result, on_error):
         try:
             proxy = Gio.DBusProxy.new_finish(result)
             proxy.call(
-                "Connect", None, Gio.DBusCallFlags.NONE, -1, None,
-                self._on_connect_done, on_error,
+                "Connect",
+                None,
+                Gio.DBusCallFlags.NONE,
+                -1,
+                None,
+                self._on_connect_done,
+                on_error,
             )
         except Exception as exc:
             print(f"[bluetooth] connect proxy failed: {exc}")
@@ -249,17 +301,28 @@ class BluetoothManager(GObject.Object):
         if not self._connection:
             return
         Gio.DBusProxy.new(
-            self._connection, _FLAGS_METHOD, None,
-            BLUEZ_SERVICE, path, DEVICE_IFACE,
-            None, self._on_disconnect_proxy_ready, None,
+            self._connection,
+            _FLAGS_METHOD,
+            None,
+            BLUEZ_SERVICE,
+            path,
+            DEVICE_IFACE,
+            None,
+            self._on_disconnect_proxy_ready,
+            None,
         )
 
     def _on_disconnect_proxy_ready(self, _source, result, _user_data):
         try:
             proxy = Gio.DBusProxy.new_finish(result)
             proxy.call(
-                "Disconnect", None, Gio.DBusCallFlags.NONE, -1, None,
-                self._on_disconnect_done, None,
+                "Disconnect",
+                None,
+                Gio.DBusCallFlags.NONE,
+                -1,
+                None,
+                self._on_disconnect_done,
+                None,
             )
         except Exception as exc:
             print(f"[bluetooth] disconnect proxy failed: {exc}")
@@ -275,12 +338,22 @@ class BluetoothManager(GObject.Object):
             return
         try:
             proxy = Gio.DBusProxy.new_sync(
-                self._connection, _FLAGS_METHOD, None,
-                BLUEZ_SERVICE, self._adapter_path, ADAPTER_IFACE, None,
+                self._connection,
+                _FLAGS_METHOD,
+                None,
+                BLUEZ_SERVICE,
+                self._adapter_path,
+                ADAPTER_IFACE,
+                None,
             )
             proxy.call(
-                "StartDiscovery", None, Gio.DBusCallFlags.NONE, -1, None,
-                self._on_start_discovery_done, None,
+                "StartDiscovery",
+                None,
+                Gio.DBusCallFlags.NONE,
+                -1,
+                None,
+                self._on_start_discovery_done,
+                None,
             )
         except Exception as exc:
             print(f"[bluetooth] discovery start: {exc}")
@@ -297,8 +370,13 @@ class BluetoothManager(GObject.Object):
             return False
         try:
             proxy = Gio.DBusProxy.new_sync(
-                self._connection, _FLAGS_METHOD, None,
-                BLUEZ_SERVICE, self._adapter_path, ADAPTER_IFACE, None,
+                self._connection,
+                _FLAGS_METHOD,
+                None,
+                BLUEZ_SERVICE,
+                self._adapter_path,
+                ADAPTER_IFACE,
+                None,
             )
             proxy.call_sync("StopDiscovery", None, Gio.DBusCallFlags.NONE, -1, None)
         except Exception:

--- a/nothing_app/bluetooth.py
+++ b/nothing_app/bluetooth.py
@@ -1,6 +1,4 @@
-import dbus
-import dbus.mainloop.glib
-from gi.repository import GLib, GObject
+from gi.repository import Gio, GLib, GObject
 
 BLUEZ_SERVICE = "org.bluez"
 ADAPTER_IFACE = "org.bluez.Adapter1"
@@ -19,6 +17,10 @@ NOTHING_PATTERNS = (
     "cmf earphone",
     "nothing phone",
 )
+
+# Lightweight proxy flags: no property caching, no auto-signal wiring.
+# Used for proxies that only need to call methods.
+_FLAGS_METHOD = Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES | Gio.DBusProxyFlags.DO_NOT_CONNECT_SIGNALS
 
 
 class BluetoothDevice:
@@ -88,96 +90,105 @@ class BluetoothManager(GObject.Object):
     def __init__(self):
         super().__init__()
         self.devices: dict[str, BluetoothDevice] = {}
-        self._bus: dbus.SystemBus | None = None
+        self._connection: Gio.DBusConnection | None = None
+        self._adapter_path: str | None = None
+        self._subs: list[int] = []
         self._available = False
         self._init_dbus()
 
     def _init_dbus(self):
         try:
-            dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-            self._bus = dbus.SystemBus()
-            self._refresh()
+            self._connection = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+            mgr = Gio.DBusProxy.new_sync(
+                self._connection, _FLAGS_METHOD, None,
+                BLUEZ_SERVICE, "/", OBJ_MANAGER_IFACE, None,
+            )
+            # Non-blocking: populates devices and emits devices-changed when ready
+            mgr.call(
+                "GetManagedObjects", None, Gio.DBusCallFlags.NONE, -1, None,
+                self._on_managed_objects, None,
+            )
             self._subscribe()
-            self._available = True
         except Exception as exc:
             print(f"[bluetooth] D-Bus init failed: {exc}")
 
-    def _refresh(self):
-        if not self._bus:
-            return
+    def _on_managed_objects(self, proxy, result, _user_data):
         try:
-            mgr = dbus.Interface(
-                self._bus.get_object(BLUEZ_SERVICE, "/"),
-                OBJ_MANAGER_IFACE,
-            )
-            objects = mgr.GetManagedObjects()
-            self.devices = {}
-            for path, ifaces in objects.items():
-                if DEVICE_IFACE not in ifaces:
-                    continue
-                props = {str(k): v for k, v in ifaces[DEVICE_IFACE].items()}
-                dev = BluetoothDevice(str(path), props)
-                if BATTERY_IFACE in ifaces:
-                    dev.battery = int(ifaces[BATTERY_IFACE].get("Percentage", 0))
-                self.devices[str(path)] = dev
+            variant = proxy.call_finish(result)
+            objects = variant.unpack()[0]
+            self._populate(objects)
+            self._available = True
+            GLib.idle_add(self.emit, "devices-changed")
         except Exception as exc:
-            print(f"[bluetooth] Refresh failed: {exc}")
+            print(f"[bluetooth] GetManagedObjects failed: {exc}")
+
+    def _populate(self, objects: dict):
+        self.devices = {}
+        self._adapter_path = None
+        for path, ifaces in objects.items():
+            if ADAPTER_IFACE in ifaces and self._adapter_path is None:
+                self._adapter_path = path
+            if DEVICE_IFACE not in ifaces:
+                continue
+            props = dict(ifaces[DEVICE_IFACE])
+            dev = BluetoothDevice(path, props)
+            if BATTERY_IFACE in ifaces:
+                dev.battery = int(ifaces[BATTERY_IFACE].get("Percentage", 0))
+            self.devices[path] = dev
 
     def _subscribe(self):
-        if not self._bus:
+        if not self._connection:
             return
         try:
-            self._bus.add_signal_receiver(
-                self._on_props_changed,
-                signal_name="PropertiesChanged",
-                dbus_interface=PROPERTIES_IFACE,
-                path_keyword="path",
-            )
-            self._bus.add_signal_receiver(
-                self._on_ifaces_added,
-                signal_name="InterfacesAdded",
-                dbus_interface=OBJ_MANAGER_IFACE,
-                bus_name=BLUEZ_SERVICE,
-            )
-            self._bus.add_signal_receiver(
-                self._on_ifaces_removed,
-                signal_name="InterfacesRemoved",
-                dbus_interface=OBJ_MANAGER_IFACE,
-                bus_name=BLUEZ_SERVICE,
-            )
+            self._subs.append(self._connection.signal_subscribe(
+                BLUEZ_SERVICE, PROPERTIES_IFACE, "PropertiesChanged",
+                None, None, Gio.DBusSignalFlags.NONE,
+                self._on_props_changed, None,
+            ))
+            self._subs.append(self._connection.signal_subscribe(
+                BLUEZ_SERVICE, OBJ_MANAGER_IFACE, "InterfacesAdded",
+                None, None, Gio.DBusSignalFlags.NONE,
+                self._on_ifaces_added, None,
+            ))
+            self._subs.append(self._connection.signal_subscribe(
+                BLUEZ_SERVICE, OBJ_MANAGER_IFACE, "InterfacesRemoved",
+                None, None, Gio.DBusSignalFlags.NONE,
+                self._on_ifaces_removed, None,
+            ))
         except Exception as exc:
             print(f"[bluetooth] Signal subscribe failed: {exc}")
 
-    def _on_props_changed(self, interface, changed, _invalidated=None, path=None):
-        if interface != DEVICE_IFACE:
+    def _on_props_changed(self, _conn, _sender, path, _iface, _signal, params, _user_data):
+        iface_name, changed, _invalidated = params.unpack()
+        if iface_name != DEVICE_IFACE:
             return
-        if not path:
-            return
-        path = str(path)
         if path not in self.devices:
             return
         dev = self.devices[path]
         old_connected = dev.connected
-        dev.update({str(k): v for k, v in changed.items()})
+        dev.update(dict(changed))
         if dev.connected != old_connected:
             sig = "device-connected" if dev.connected else "device-disconnected"
             GLib.idle_add(self.emit, sig, path)
         GLib.idle_add(self.emit, "devices-changed")
 
-    def _on_ifaces_added(self, path, ifaces):
+    def _on_ifaces_added(self, _conn, _sender, _path, _iface, _signal, params, _user_data):
+        obj_path, ifaces = params.unpack()
+        if ADAPTER_IFACE in ifaces and self._adapter_path is None:
+            self._adapter_path = obj_path
         if DEVICE_IFACE not in ifaces:
             return
-        props = {str(k): v for k, v in ifaces[DEVICE_IFACE].items()}
-        dev = BluetoothDevice(str(path), props)
+        props = dict(ifaces[DEVICE_IFACE])
+        dev = BluetoothDevice(obj_path, props)
         if BATTERY_IFACE in ifaces:
             dev.battery = int(ifaces[BATTERY_IFACE].get("Percentage", 0))
-        self.devices[str(path)] = dev
+        self.devices[obj_path] = dev
         GLib.idle_add(self.emit, "devices-changed")
 
-    def _on_ifaces_removed(self, path, ifaces):
-        path = str(path)
-        if DEVICE_IFACE in ifaces and path in self.devices:
-            del self.devices[path]
+    def _on_ifaces_removed(self, _conn, _sender, _path, _iface, _signal, params, _user_data):
+        obj_path, ifaces = params.unpack()
+        if DEVICE_IFACE in ifaces and obj_path in self.devices:
+            del self.devices[obj_path]
             GLib.idle_add(self.emit, "devices-changed")
 
     @property
@@ -191,56 +202,105 @@ class BluetoothManager(GObject.Object):
         return [d for d in self.get_all() if d.is_nothing]
 
     def refresh(self):
-        self._refresh()
-        self.emit("devices-changed")
+        if not self._connection:
+            return
+        try:
+            mgr = Gio.DBusProxy.new_sync(
+                self._connection, _FLAGS_METHOD, None,
+                BLUEZ_SERVICE, "/", OBJ_MANAGER_IFACE, None,
+            )
+            mgr.call(
+                "GetManagedObjects", None, Gio.DBusCallFlags.NONE, -1, None,
+                self._on_managed_objects, None,
+            )
+        except Exception as exc:
+            print(f"[bluetooth] refresh: {exc}")
 
     def connect_device(self, path: str, on_error=None):
-        if not self._bus:
+        if not self._connection:
             return
+        Gio.DBusProxy.new(
+            self._connection, _FLAGS_METHOD, None,
+            BLUEZ_SERVICE, path, DEVICE_IFACE,
+            None, self._on_connect_proxy_ready, on_error,
+        )
 
-        def _err(e):
-            print(f"[BT] connect error: {e}")
+    def _on_connect_proxy_ready(self, _source, result, on_error):
+        try:
+            proxy = Gio.DBusProxy.new_finish(result)
+            proxy.call(
+                "Connect", None, Gio.DBusCallFlags.NONE, -1, None,
+                self._on_connect_done, on_error,
+            )
+        except Exception as exc:
+            print(f"[bluetooth] connect proxy failed: {exc}")
             if on_error:
                 GLib.idle_add(on_error)
 
+    def _on_connect_done(self, proxy, result, on_error):
         try:
-            iface = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, path), DEVICE_IFACE)
-            iface.Connect(reply_handler=lambda: None, error_handler=_err)
+            proxy.call_finish(result)
         except Exception as exc:
-            print(f"[bluetooth] connect {path}: {exc}")
+            print(f"[BT] connect error: {exc}")
             if on_error:
                 GLib.idle_add(on_error)
 
     def disconnect_device(self, path: str):
-        if not self._bus:
+        if not self._connection:
             return
+        Gio.DBusProxy.new(
+            self._connection, _FLAGS_METHOD, None,
+            BLUEZ_SERVICE, path, DEVICE_IFACE,
+            None, self._on_disconnect_proxy_ready, None,
+        )
+
+    def _on_disconnect_proxy_ready(self, _source, result, _user_data):
         try:
-            iface = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, path), DEVICE_IFACE)
-            iface.Disconnect(
-                reply_handler=lambda: None,
-                error_handler=lambda e: print(f"[BT] disconnect error: {e}"),
+            proxy = Gio.DBusProxy.new_finish(result)
+            proxy.call(
+                "Disconnect", None, Gio.DBusCallFlags.NONE, -1, None,
+                self._on_disconnect_done, None,
             )
         except Exception as exc:
-            print(f"[bluetooth] disconnect {path}: {exc}")
+            print(f"[bluetooth] disconnect proxy failed: {exc}")
+
+    def _on_disconnect_done(self, proxy, result, _user_data):
+        try:
+            proxy.call_finish(result)
+        except Exception as exc:
+            print(f"[BT] disconnect error: {exc}")
 
     def start_discovery(self):
-        if not self._bus:
+        if not self._connection or not self._adapter_path:
             return
         try:
-            mgr = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, "/"), OBJ_MANAGER_IFACE)
-            for path, ifaces in mgr.GetManagedObjects().items():
-                if ADAPTER_IFACE in ifaces:
-                    adapter = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, path), ADAPTER_IFACE)
-                    adapter.StartDiscovery()
-                    GLib.timeout_add_seconds(30, self._stop_discovery_on_path, str(path))
-                    break
+            proxy = Gio.DBusProxy.new_sync(
+                self._connection, _FLAGS_METHOD, None,
+                BLUEZ_SERVICE, self._adapter_path, ADAPTER_IFACE, None,
+            )
+            proxy.call(
+                "StartDiscovery", None, Gio.DBusCallFlags.NONE, -1, None,
+                self._on_start_discovery_done, None,
+            )
         except Exception as exc:
             print(f"[bluetooth] discovery start: {exc}")
 
-    def _stop_discovery_on_path(self, path: str):
+    def _on_start_discovery_done(self, proxy, result, _user_data):
         try:
-            adapter = dbus.Interface(self._bus.get_object(BLUEZ_SERVICE, path), ADAPTER_IFACE)
-            adapter.StopDiscovery()
+            proxy.call_finish(result)
+            GLib.timeout_add_seconds(30, self._stop_discovery)
+        except Exception as exc:
+            print(f"[bluetooth] start discovery error: {exc}")
+
+    def _stop_discovery(self):
+        if not self._connection or not self._adapter_path:
+            return False
+        try:
+            proxy = Gio.DBusProxy.new_sync(
+                self._connection, _FLAGS_METHOD, None,
+                BLUEZ_SERVICE, self._adapter_path, ADAPTER_IFACE, None,
+            )
+            proxy.call_sync("StopDiscovery", None, Gio.DBusCallFlags.NONE, -1, None)
         except Exception:
             pass
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 
 dependencies = [
     "PyGObject>=3.42",
-    "dbus-python>=1.3",
 ]
 
 [project.scripts]
@@ -41,7 +40,10 @@ include = ["nothing_app*"]
 nothing_app = ["data/*.css", "data/*.desktop"]
 
 [project.optional-dependencies]
-dev = ["ruff"]
+dev = ["ruff", "pytest", "pytest-cov"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 110

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "something-x"
-version = "1.6.0"
+version = "1.7.0"
 description     = "Something X device manager for Omarchy / Linux"
 readme          = "README.md"
 license         = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "something-x"
-version = "1.5.0"
+version = "1.6.0"
 description     = "Something X device manager for Omarchy / Linux"
 readme          = "README.md"
 license         = { text = "MIT" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_glib(monkeypatch):
+    """Replace GLib scheduling calls with no-ops so tests don't need a running main loop."""
+    from gi.repository import GLib
+
+    monkeypatch.setattr(GLib, "idle_add", MagicMock(return_value=0))
+    monkeypatch.setattr(GLib, "timeout_add", MagicMock(return_value=0))
+    monkeypatch.setattr(GLib, "timeout_add_seconds", MagicMock(return_value=0))
+    monkeypatch.setattr(GLib, "source_remove", MagicMock(return_value=True))
+
+
+@pytest.fixture()
+def mock_profiles(monkeypatch):
+    from nothing_app import profiles
+
+    monkeypatch.setattr(profiles, "save", MagicMock())
+    monkeypatch.setattr(profiles, "load", MagicMock(return_value={}))
+    monkeypatch.setattr(profiles, "set_last_device", MagicMock())
+
+
+def build_device_frame(cmd_id: int, payload: bytes = b"", fsn: int = 1) -> bytes:
+    """Build a 0x55 device-response frame (with CRC) for the given command and payload.
+
+    Device responses have bit15 of cmd cleared; _process_x55 restores it via | 0x8000.
+    ctrl=0x0160 has bit5 set → CRC appended.
+    """
+    SOF = 0x55
+    CTRL = 0x0160
+    cmd_raw = cmd_id & 0x7FFF  # device clears bit15 on responses
+    header = struct.pack("<BHHH", SOF, CTRL, cmd_raw, len(payload)) + bytes([fsn])
+    from nothing_app.protocol import _crc16
+
+    crc = _crc16(header + payload)
+    return header + payload + struct.pack("<H", crc)

--- a/tests/test_bluetooth.py
+++ b/tests/test_bluetooth.py
@@ -1,0 +1,136 @@
+"""Tests for BluetoothDevice data class and device_icon_name helper."""
+
+import pytest
+
+from nothing_app.bluetooth import BluetoothDevice, device_icon_name
+
+
+def make_device(name="Nothing Ear (2)", icon="audio-headphones", connected=False):
+    return BluetoothDevice(
+        "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+        {
+            "Address": "AA:BB:CC:DD:EE:FF",
+            "Name": name,
+            "Icon": icon,
+            "Connected": connected,
+            "Paired": True,
+        },
+    )
+
+
+# ── BluetoothDevice construction ──────────────────────────────────────────────
+
+
+def test_address_stored():
+    dev = make_device()
+    assert dev.address == "AA:BB:CC:DD:EE:FF"
+
+
+def test_name_stored():
+    dev = make_device(name="CMF Buds Pro 2")
+    assert dev.name == "CMF Buds Pro 2"
+
+
+def test_connected_flag():
+    assert make_device(connected=True).connected is True
+    assert make_device(connected=False).connected is False
+
+
+def test_is_nothing_true_for_known_patterns():
+    for name in [
+        "Nothing Ear (2)",
+        "Nothing Ear (1)",
+        "Nothing Ear (A)",
+        "Ear (Stick)",
+        "CMF Buds Pro 2",
+        "CMF Earphone 1",
+        "Nothing Phone (2)",
+    ]:
+        assert make_device(name=name).is_nothing is True, f"{name!r} should be recognised"
+
+
+def test_is_nothing_false_for_unknown():
+    for name in ["AirPods Pro", "Galaxy Buds2", "Sony WH-1000XM5", "Jabra Elite 7"]:
+        assert make_device(name=name).is_nothing is False
+
+
+def test_battery_default_none():
+    assert make_device().battery is None
+
+
+def test_repr_connected():
+    dev = make_device(connected=True)
+    assert "●" in repr(dev)
+
+
+def test_repr_disconnected():
+    dev = make_device(connected=False)
+    assert "○" in repr(dev)
+
+
+# ── BluetoothDevice.update ────────────────────────────────────────────────────
+
+
+def test_update_connected():
+    dev = make_device(connected=False)
+    dev.update({"Connected": True})
+    assert dev.connected is True
+
+
+def test_update_name():
+    dev = make_device(name="Old Name")
+    dev.update({"Name": "New Name"})
+    assert dev.name == "New Name"
+
+
+def test_update_ignores_unknown_keys():
+    dev = make_device()
+    dev.update({"UnknownKey": "value"})  # should not raise
+
+
+def test_update_alias_only_when_name_empty():
+    dev = BluetoothDevice("/path", {"Address": "AA:BB:CC:DD:EE:FF", "Name": "", "Alias": "My Device"})
+    dev.update({"Alias": "Better Name"})
+    assert dev.name == "Better Name"
+
+    dev2 = make_device(name="Existing")
+    dev2.update({"Alias": "Should Not Replace"})
+    assert dev2.name == "Existing"
+
+
+# ── device_icon_name ──────────────────────────────────────────────────────────
+
+
+def test_none_device_returns_default():
+    assert device_icon_name(None) == "audio-headphones-symbolic"
+
+
+def test_headphones_icon_mapped():
+    dev = make_device(icon="audio-headphones")
+    assert device_icon_name(dev) == "audio-headphones-symbolic"
+
+
+def test_headset_icon_mapped():
+    dev = make_device(icon="audio-headset")
+    assert device_icon_name(dev) == "audio-headset-symbolic"
+
+
+def test_watch_name_returns_alarm():
+    for name in ["Galaxy Watch 5", "Amazfit GTR", "Fenix 7"]:
+        dev = make_device(name=name)
+        assert device_icon_name(dev) == "alarm-symbolic", f"expected alarm for {name!r}"
+
+
+def test_ear_stick_returns_microphone():
+    dev = make_device(name="Nothing Ear (Stick)")
+    assert device_icon_name(dev) == "audio-input-microphone-symbolic"
+
+
+def test_phone_name_returns_phone():
+    dev = make_device(name="Nothing Phone (2)", icon="unknown-icon")
+    assert device_icon_name(dev) == "phone-symbolic"
+
+
+def test_unknown_icon_falls_back_to_headphones():
+    dev = make_device(name="Random Gadget", icon="unknown-xyz")
+    assert device_icon_name(dev) == "audio-headphones-symbolic"

--- a/tests/test_crc.py
+++ b/tests/test_crc.py
@@ -1,0 +1,48 @@
+import struct
+
+from nothing_app.protocol import _CMD_PROTO_VERSION, _CTRL_HOST_CRC, _SOF, _crc16
+
+
+def test_returns_uint16():
+    for data in [b"", b"\x00", b"\xff", b"\x55" * 8, b"hello world"]:
+        result = _crc16(data)
+        assert isinstance(result, int)
+        assert 0 <= result <= 0xFFFF
+
+
+def test_deterministic():
+    data = b"\x55\x60\x01\x01\xc0\x00\x00\x01"
+    assert _crc16(data) == _crc16(data)
+
+
+def test_empty_is_init_value():
+    # With no bytes processed the accumulator stays at the init value 0xFFFF.
+    assert _crc16(b"") == 0xFFFF
+
+
+def test_single_bit_flip_detected():
+    data = b"\x55\x60\x01\x01\xc0\x00\x00\x01\x42\xab"
+    flipped = bytes([data[0] ^ 0x01]) + data[1:]
+    assert _crc16(data) != _crc16(flipped)
+
+
+def test_different_inputs_differ():
+    assert _crc16(b"\x00\x00") != _crc16(b"\x00\x01")
+    assert _crc16(b"\x55\x60\x01") != _crc16(b"\x55\x60\x02")
+    assert _crc16(b"\xaa") != _crc16(b"\xab")
+
+
+def test_probe_frame_crc_is_stable():
+    # The probe frame sent during channel discovery must always produce the same CRC.
+    header = struct.pack("<BHHH", _SOF, _CTRL_HOST_CRC, _CMD_PROTO_VERSION, 0) + bytes([0x01])
+    crc1 = _crc16(header)
+    crc2 = _crc16(header)
+    assert crc1 == crc2
+    assert 0 <= crc1 <= 0xFFFF
+
+
+def test_payload_changes_crc():
+    header = struct.pack("<BHHH", _SOF, _CTRL_HOST_CRC, _CMD_PROTO_VERSION, 3) + bytes([0x01])
+    crc_a = _crc16(header + b"\x01\x02\x03")
+    crc_b = _crc16(header + b"\x01\x02\x04")
+    assert crc_a != crc_b

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,90 @@
+"""Tests for the profiles persistence layer."""
+
+import json
+import os
+
+import pytest
+
+from nothing_app import profiles
+from nothing_app.protocol import ANCMode
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path, monkeypatch):
+    """Point the profiles module at a temp directory so tests never touch ~/.config."""
+    monkeypatch.setattr(profiles, "_DIR", str(tmp_path))
+    monkeypatch.setattr(profiles, "_PROFILES_FILE", str(tmp_path / "profiles.json"))
+    monkeypatch.setattr(profiles, "_LAST_DEV_FILE", str(tmp_path / "last_device"))
+
+
+# ── load ──────────────────────────────────────────────────────────────────────
+
+
+def test_load_missing_file_returns_empty():
+    result = profiles.load("AA:BB:CC:DD:EE:FF")
+    assert result == {}
+
+
+def test_load_bad_json_returns_empty(tmp_path):
+    (tmp_path / "profiles.json").write_text("not json")
+    result = profiles.load("AA:BB:CC:DD:EE:FF")
+    assert result == {}
+
+
+def test_load_unknown_address_returns_empty():
+    profiles.save("11:22:33:44:55:66", ANCMode.OFF, "Balanced")
+    result = profiles.load("AA:BB:CC:DD:EE:FF")
+    assert result == {}
+
+
+# ── save / load roundtrip ─────────────────────────────────────────────────────
+
+
+def test_save_and_load_roundtrip():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.save(addr, ANCMode.NOISE_CANCELLATION, "More Bass")
+    p = profiles.load(addr)
+    assert p["anc"] == ANCMode.NOISE_CANCELLATION
+    assert p["eq"] == "More Bass"
+
+
+def test_save_multiple_devices():
+    profiles.save("AA:BB:CC:DD:EE:FF", ANCMode.OFF, "Balanced")
+    profiles.save("11:22:33:44:55:66", ANCMode.TRANSPARENCY, "Voice")
+    assert profiles.load("AA:BB:CC:DD:EE:FF")["anc"] == ANCMode.OFF
+    assert profiles.load("11:22:33:44:55:66")["anc"] == ANCMode.TRANSPARENCY
+
+
+def test_save_overwrites_existing():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.save(addr, ANCMode.OFF, "Balanced")
+    profiles.save(addr, ANCMode.NOISE_CANCELLATION, "More Treble")
+    p = profiles.load(addr)
+    assert p["anc"] == ANCMode.NOISE_CANCELLATION
+    assert p["eq"] == "More Treble"
+
+
+def test_save_creates_directory(tmp_path, monkeypatch):
+    nested = tmp_path / "deep" / "nested"
+    monkeypatch.setattr(profiles, "_DIR", str(nested))
+    monkeypatch.setattr(profiles, "_PROFILES_FILE", str(nested / "profiles.json"))
+    profiles.save("AA:BB:CC:DD:EE:FF", ANCMode.OFF, "Balanced")
+    assert (nested / "profiles.json").exists()
+
+
+# ── last_device ───────────────────────────────────────────────────────────────
+
+
+def test_get_last_device_missing_returns_none():
+    assert profiles.get_last_device() is None
+
+
+def test_set_and_get_last_device():
+    profiles.set_last_device("AA:BB:CC:DD:EE:FF")
+    assert profiles.get_last_device() == "AA:BB:CC:DD:EE:FF"
+
+
+def test_set_last_device_overwrites():
+    profiles.set_last_device("11:22:33:44:55:66")
+    profiles.set_last_device("AA:BB:CC:DD:EE:FF")
+    assert profiles.get_last_device() == "AA:BB:CC:DD:EE:FF"

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,273 @@
+"""Tests for the 0x55 frame parser and device-state parsing logic."""
+
+import pytest
+
+from nothing_app.protocol import (
+    ANCMode,
+    NothingDevice,
+    _CMD_BATTERY,
+    _CMD_EARPHONE,
+    _CMD_EQ_MODE,
+    _CMD_NOISE_RED,
+    _CMD_REMOTE_CONF,
+    _CMD_HOST_VERSION,
+    _prioritise,
+)
+from tests.conftest import build_device_frame
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def make_device() -> NothingDevice:
+    return NothingDevice("AA:BB:CC:DD:EE:FF")
+
+
+# ── _prioritise ───────────────────────────────────────────────────────────────
+
+
+def test_prioritise_puts_15_17_16_first():
+    result = _prioritise([1, 2, 15, 16, 17, 18])
+    assert result[:3] == [15, 17, 16]
+
+
+def test_prioritise_only_present_channels_promoted():
+    result = _prioritise([1, 2, 17])
+    assert result[0] == 17
+    assert set(result) == {1, 2, 17}
+
+
+def test_prioritise_preserves_all_channels():
+    channels = [3, 5, 15, 16, 17, 20]
+    result = _prioritise(channels)
+    assert sorted(result) == sorted(channels)
+
+
+def test_prioritise_no_priority_channels():
+    result = _prioritise([1, 2, 3])
+    assert set(result) == {1, 2, 3}
+
+
+# ── _parse_battery ────────────────────────────────────────────────────────────
+
+
+def test_parse_battery_basic():
+    dev = make_device()
+    # count=3, [type=2 left=80%], [type=3 right=72%], [type=4 case=90%]
+    payload = bytes([0x03, 0x02, 80, 0x03, 72, 0x04, 90])
+    changed = dev._parse_battery(payload)
+    assert changed is True
+    assert dev.state.left_battery == 80
+    assert dev.state.right_battery == 72
+    assert dev.state.case_battery == 90
+
+
+def test_parse_battery_charging_flag_stripped():
+    dev = make_device()
+    # bit7 = charging; actual percent is bits[6:0]
+    payload = bytes([0x01, 0x02, 0x80 | 45])  # left=45%, charging
+    dev._parse_battery(payload)
+    assert dev.state.left_battery == 45
+
+
+def test_parse_battery_too_short_returns_false():
+    dev = make_device()
+    assert dev._parse_battery(b"") is False
+    assert dev._parse_battery(b"\x01\x02") is False
+
+
+def test_parse_battery_no_change_returns_false():
+    dev = make_device()
+    payload = bytes([0x01, 0x02, 50])
+    dev._parse_battery(payload)
+    changed = dev._parse_battery(payload)  # same value second time
+    assert changed is False
+
+
+def test_parse_battery_updates_only_present_types():
+    dev = make_device()
+    # Only right bud present
+    payload = bytes([0x01, 0x03, 60])
+    dev._parse_battery(payload)
+    assert dev.state.right_battery == 60
+    assert dev.state.left_battery == -1   # untouched default
+    assert dev.state.case_battery == -1
+
+
+# ── _parse_anc ────────────────────────────────────────────────────────────────
+
+
+def test_parse_anc_off():
+    dev = make_device()
+    # type=1 mode=OFF(5), type=2 level=2 (has ANC)
+    payload = bytes([0x01, 5, 0x00, 0x02, 2, 0x00])
+    dev._parse_anc(payload)
+    assert dev.state.anc_mode == ANCMode.OFF
+
+
+def test_parse_anc_noise_cancellation():
+    dev = make_device()
+    payload = bytes([0x01, 1, 0x00, 0x02, 2, 0x00])  # mode=STRONG(1)
+    dev._parse_anc(payload)
+    assert dev.state.anc_mode == ANCMode.NOISE_CANCELLATION
+
+
+def test_parse_anc_transparency():
+    dev = make_device()
+    payload = bytes([0x01, 7, 0x00, 0x02, 0xFE, 0x00])  # mode=transparency, level=0xFE
+    dev._parse_anc(payload)
+    assert dev.state.anc_mode == ANCMode.TRANSPARENCY
+
+
+def test_parse_anc_detects_full_modes_when_level_1_to_4():
+    dev = make_device()
+    payload = bytes([0x01, 1, 0x00, 0x02, 3, 0x00])  # level=3 → all 3 modes supported
+    dev._parse_anc(payload)
+    assert dev.state.supported_anc_modes == frozenset(
+        [ANCMode.OFF, ANCMode.NOISE_CANCELLATION, ANCMode.TRANSPARENCY]
+    )
+
+
+def test_parse_anc_detects_limited_modes_when_level_0xfe():
+    dev = make_device()
+    payload = bytes([0x01, 7, 0x00, 0x02, 0xFE, 0x00])  # level=0xFE → off+transparency only
+    dev._parse_anc(payload)
+    assert dev.state.supported_anc_modes == frozenset([ANCMode.OFF, ANCMode.TRANSPARENCY])
+
+
+def test_parse_anc_supported_modes_locked_after_first_level():
+    dev = make_device()
+    payload1 = bytes([0x01, 1, 0x00, 0x02, 2, 0x00])
+    payload2 = bytes([0x01, 7, 0x00, 0x02, 0xFE, 0x00])
+    dev._parse_anc(payload1)
+    first = dev.state.supported_anc_modes
+    dev._parse_anc(payload2)
+    assert dev.state.supported_anc_modes == first  # locked after first observation
+
+
+def test_parse_anc_too_short_returns_false():
+    dev = make_device()
+    assert dev._parse_anc(b"") is False
+    assert dev._parse_anc(b"\x01\x01") is False
+
+
+# ── _parse_earphone_status ────────────────────────────────────────────────────
+
+
+def test_parse_earphone_both_in_ear():
+    dev = make_device()
+    # count=2, [type=2 left val=0x04(in_ear)], [type=3 right val=0x04]
+    payload = bytes([0x02, 0x02, 0x04, 0x03, 0x04])
+    changed = dev._parse_earphone_status(payload)
+    assert changed is True
+    assert dev.state.left_wearing is True
+    assert dev.state.right_wearing is True
+
+
+def test_parse_earphone_neither_in_ear():
+    dev = make_device()
+    dev.state.left_wearing = True
+    dev.state.right_wearing = True
+    payload = bytes([0x02, 0x02, 0x00, 0x03, 0x00])  # bit2 not set → not in ear
+    changed = dev._parse_earphone_status(payload)
+    assert changed is True
+    assert dev.state.left_wearing is False
+    assert dev.state.right_wearing is False
+
+
+def test_parse_earphone_no_change_returns_false():
+    dev = make_device()
+    payload = bytes([0x02, 0x02, 0x00, 0x03, 0x00])
+    dev._parse_earphone_status(payload)
+    changed = dev._parse_earphone_status(payload)
+    assert changed is False
+
+
+def test_parse_earphone_too_short_returns_false():
+    dev = make_device()
+    assert dev._parse_earphone_status(b"") is False
+    assert dev._parse_earphone_status(b"\x01\x02") is False
+
+
+def test_parse_earphone_ignores_non_bud_types():
+    dev = make_device()
+    # type=4 (case), type=5 (tws) — should be ignored
+    payload = bytes([0x02, 0x04, 0x04, 0x05, 0x04])
+    changed = dev._parse_earphone_status(payload)
+    assert changed is False
+
+
+# ── _parse_remote_conf (serial number) ───────────────────────────────────────
+
+
+def test_dispatch_remote_conf_parses_serial(mock_profiles):
+    dev = make_device()
+    # "device_id,4,SH10212543006451\n"
+    raw = "1,4,SH10212543006451\n".encode()
+    dev._dispatch_x55(_CMD_REMOTE_CONF, raw)
+    assert dev.state.serial_number == "SH10212543006451"
+
+
+def test_dispatch_remote_conf_ignores_other_fields(mock_profiles):
+    dev = make_device()
+    raw = "1,1,some_value\n1,2,other\n1,4,SERIAL123\n".encode()
+    dev._dispatch_x55(_CMD_REMOTE_CONF, raw)
+    assert dev.state.serial_number == "SERIAL123"
+
+
+# ── _parse_host_version (firmware) ───────────────────────────────────────────
+
+
+def test_dispatch_host_version(mock_profiles):
+    dev = make_device()
+    dev._dispatch_x55(_CMD_HOST_VERSION, b"2.0.5\x00")
+    assert dev.state.firmware_version == "2.0.5"
+
+
+# ── _process_x55 (frame parser integration) ──────────────────────────────────
+
+
+def test_process_x55_battery_frame(mock_profiles):
+    dev = make_device()
+    payload = bytes([0x03, 0x02, 80, 0x03, 72, 0x04, 90])
+    frame = build_device_frame(_CMD_BATTERY, payload)
+    dev._process_x55(frame)
+    assert dev.state.left_battery == 80
+    assert dev.state.right_battery == 72
+    assert dev.state.case_battery == 90
+
+
+def test_process_x55_anc_frame(mock_profiles):
+    dev = make_device()
+    payload = bytes([0x01, 7, 0x00, 0x02, 0xFE, 0x00])
+    frame = build_device_frame(_CMD_NOISE_RED, payload)
+    dev._process_x55(frame)
+    assert dev.state.anc_mode == ANCMode.TRANSPARENCY
+
+
+def test_process_x55_crc_error_still_advances_buffer(mock_profiles):
+    dev = make_device()
+    payload = bytes([0x01, 0x02, 50])
+    frame = bytearray(build_device_frame(_CMD_BATTERY, payload))
+    frame[-1] ^= 0xFF  # corrupt CRC
+    # Should not raise; buffer should be consumed past the bad frame
+    remaining = dev._process_x55(bytes(frame))
+    assert remaining == b""
+
+
+def test_process_x55_incomplete_frame_held_in_buffer(mock_profiles):
+    dev = make_device()
+    payload = bytes([0x01, 0x02, 50])
+    frame = build_device_frame(_CMD_BATTERY, payload)
+    partial = frame[:5]  # only first 5 bytes
+    remaining = dev._process_x55(partial)
+    assert remaining == partial  # held until rest arrives
+
+
+def test_process_x55_two_consecutive_frames(mock_profiles):
+    dev = make_device()
+    f1 = build_device_frame(_CMD_BATTERY, bytes([0x01, 0x02, 70]))
+    f2 = build_device_frame(_CMD_NOISE_RED, bytes([0x01, 7, 0x00, 0x02, 0xFE, 0x00]))
+    dev._process_x55(f1 + f2)
+    assert dev.state.left_battery == 70
+    assert dev.state.anc_mode == ANCMode.TRANSPARENCY


### PR DESCRIPTION
## What

Replaces the `dbus-python` Bluetooth backend with PyGObject's native `Gio` D-Bus
bindings, and adds a full unit test suite covering the protocol codec, Bluetooth
device layer, and profile persistence.

## Changes

### Bluetooth (`nothing_app/bluetooth.py`)
- `dbus-python` dependency dropped — PyGObject's `Gio` is already required and
  handles everything natively
- `GetManagedObjects` is now non-blocking (async callback); the UI never stalls
  on startup while BlueZ enumerates devices
- `connect_device` / `disconnect_device` fully async via `Gio.DBusProxy.new()` →
  `proxy.call()` — no more `reply_handler` workaround
- Signal subscriptions use `Gio.DBusConnection.signal_subscribe()` — one clean
  call per signal instead of three `add_signal_receiver` calls
- Adapter path is cached during `_populate()`; `start_discovery` no longer calls
  `GetManagedObjects` a second time

### Tests (`tests/`)
65 tests, no hardware required, no running main loop needed:

| File | Covers |
|---|---|
| `test_crc.py` | CRC16 determinism, bit-flip detection, edge inputs |
| `test_protocol.py` | Battery / ANC / earphone parsing, serial & firmware dispatch, 0x55 frame parser (single, chained, partial buffer, corrupt CRC) |
| `test_bluetooth.py` | `BluetoothDevice` construction & `update()`, `is_nothing` patterns, `device_icon_name` all branches |
| `test_profiles.py` | Save/load roundtrip, multi-device, overwrite, missing file, bad JSON, last-device persistence |

### CI (`.github/workflows/ci.yml`)
- New parallel `test` job: installs PyGObject system deps, runs `pytest --cov`
- CI and coverage badges added to README