### PR TITLE
feat: show current version at runtime and in GUI header

### DIFF
--- a/nothing_app/__init__.py
+++ b/nothing_app/__init__.py
@@ -1,2 +1,21 @@
-__version__ = "1.0.0"
+from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PNF
+
+
+def _resolve_version() -> str:
+    for pkg in ("something-x", "something-x-dev"):
+        try:
+            return _pkg_version(pkg)
+        except _PNF:
+            pass
+    try:
+        import tomllib
+        import pathlib
+
+        data = tomllib.loads((pathlib.Path(__file__).parent.parent / "pyproject.toml").read_text())
+        return data["project"]["version"] + "+src"
+    except Exception:
+        return "0.0.0+dev"
+
+
+__version__ = _resolve_version()
 APP_ID = "com.something.x.omarchy"

--- a/nothing_app/application.py
+++ b/nothing_app/application.py
@@ -222,13 +222,17 @@ def _run_cli(argv: list[str]) -> int:
 
 
 def _print_help():
+    from . import __version__
+
     print(
-        "Usage:\n"
+        f"Something X {__version__}\n"
+        "\nUsage:\n"
         "  something-x                             launch GUI\n"
         "  something-x --battery                   print battery levels\n"
         "  something-x --anc off|on|transparency   set ANC mode\n"
         "  something-x --eq balanced|bass|treble|voice  set EQ preset\n"
         "  something-x --device AA:BB:CC:DD:EE:FF  target specific device\n"
+        "  something-x --version                   print version and exit\n"
     )
 
 
@@ -238,6 +242,12 @@ def main():
 
     if "--help" in argv or "-h" in argv:
         _print_help()
+        sys.exit(0)
+
+    if "--version" in argv or "-V" in argv:
+        from . import __version__
+
+        print(f"something-x {__version__}")
         sys.exit(0)
 
     if any(f in argv for f in cli_flags):

--- a/nothing_app/window.py
+++ b/nothing_app/window.py
@@ -4,6 +4,7 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw
 
+from . import __version__
 from .bluetooth import BluetoothDevice, BluetoothManager
 from .protocol import NothingDevice
 from .pages.home import HomePage
@@ -60,7 +61,10 @@ class SomethingXWindow(Adw.ApplicationWindow):
 
         header = Adw.HeaderBar()
         header.add_css_class("nothing-header")
-        header.set_show_title(True)
+        title_widget = Adw.WindowTitle()
+        title_widget.set_title("Something X")
+        title_widget.set_subtitle(__version__)
+        header.set_title_widget(title_widget)
 
         bt_btn = Gtk.Button.new_from_icon_name("bluetooth-symbolic")
         bt_btn.set_tooltip_text("Bluetooth settings")


### PR DESCRIPTION
## Summary

- `__init__.py` resolves `__version__` at runtime via `importlib.metadata` — `1.7.0` on stable, `1.7.0.dev42` on dev channel, `1.7.0+src` from source clone, `0.0.0+dev` as fallback
- `--version` / `-V` CLI flag — prints `something-x <version>` and exits; `--help` also shows version in header line
- Home header bar uses `Adw.WindowTitle` with version as subtitle, visible under "Something X"