### PR TITLE
chore: replace static version with setuptools-scm dynamic versioning

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -18,30 +18,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      # ── Compute dev version ─────────────────────────────────────────────
-      - name: Compute dev version
+      # ── Get version from setuptools-scm ────────────────────────────────
+      # After tag v1.7.0, develop automatically produces 1.7.1.devN
+      - name: Get dev version
         id: version
         run: |
-          CURRENT=$(python3 -c "
-          import re, sys
-          m = re.search(r'version\s*=\s*\"([^\"]+)\"', open('pyproject.toml').read())
-          print(m.group(1) if m else sys.exit(1))
-          ")
-          DEV_VERSION="${CURRENT}.dev${{ github.run_number }}"
+          pip install setuptools-scm
+          DEV_VERSION=$(python3 -m setuptools_scm)
           SHORT_SHA=$(git rev-parse --short HEAD)
-
-          echo "current=$CURRENT"       >> $GITHUB_OUTPUT
           echo "dev_version=$DEV_VERSION" >> $GITHUB_OUTPUT
-          echo "short_sha=$SHORT_SHA"   >> $GITHUB_OUTPUT
+          echo "short_sha=$SHORT_SHA"     >> $GITHUB_OUTPUT
           echo "Dev version: $DEV_VERSION (sha: $SHORT_SHA)"
 
-      # ── Patch pyproject.toml for dev build ──────────────────────────────
-      - name: Patch pyproject.toml
+      # ── Patch package name for dev channel ─────────────────────────────
+      - name: Patch package name
         run: |
           sed -i 's/^name\s*=\s*"something-x"/name            = "something-x-dev"/' pyproject.toml
-          sed -i "s/^version = \"${{ steps.version.outputs.current }}\"/version = \"${{ steps.version.outputs.dev_version }}\"/" pyproject.toml
           sed -i 's/^something-x = /something-x-dev = /' pyproject.toml
-          grep -E "^name|^version|something-x" pyproject.toml
+          grep -E "^name|something-x" pyproject.toml
 
       # ── Build wheel + sdist ─────────────────────────────────────────────
       - name: Set up Python
@@ -55,29 +49,48 @@ jobs:
           python -m build
           ls dist/
 
+      # ── Generate changelog with git-cliff ──────────────────────────────
+      - name: Install git-cliff
+        run: pip install git-cliff
+
+      - name: Generate pre-release notes
+        run: |
+          git cliff --unreleased --strip all 2>/dev/null > /tmp/cliff_body.md
+          if [ ! -s /tmp/cliff_body.md ]; then
+            echo "No user-facing changes since last release." > /tmp/cliff_body.md
+          fi
+
+          cat > /tmp/release_notes.md <<HEADER
+          ## something-x-dev ${{ steps.version.outputs.dev_version }}
+
+          > Pre-release build from \`develop\` — not for production use.
+
+          **Commit**: \`${{ steps.version.outputs.short_sha }}\`
+
+          ### Changes since last stable release
+
+          HEADER
+          cat /tmp/cliff_body.md >> /tmp/release_notes.md
+          cat >> /tmp/release_notes.md <<'FOOTER'
+
+          ### Install
+
+          ```bash
+          pip install something-x-dev==${{ steps.version.outputs.dev_version }}
+
+          # Or download the wheel below
+          pip install something_x_dev-${{ steps.version.outputs.dev_version }}-py3-none-any.whl
+          ```
+          FOOTER
+
       # ── GitHub pre-release ──────────────────────────────────────────────
       - name: Create GitHub pre-release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: "dev-${{ steps.version.outputs.short_sha }}"
           prerelease: true
-          generate_release_notes: true
+          body_path: /tmp/release_notes.md
           files: dist/*
-          body: |
-            ## something-x-dev ${{ steps.version.outputs.dev_version }}
-
-            > Pre-release build from `develop` — not for production use.
-
-            **Commit**: `${{ steps.version.outputs.short_sha }}`
-
-            ### Install
-
-            ```bash
-            pip install something-x-dev==${{ steps.version.outputs.dev_version }}
-
-            # Or download the wheel below
-            pip install something_x_dev-${{ steps.version.outputs.dev_version }}-py3-none-any.whl
-            ```
 
       # ── Publish to PyPI (OIDC — requires trusted publisher configured) ──
       - name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Skip if the commit was made by the bot itself (version bump commit)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     steps:
@@ -27,30 +26,26 @@ jobs:
           COMMIT_MSG=$(git log -1 --pretty=%B)
           echo "Commit: $COMMIT_MSG"
 
-          CURRENT=$(python3 -c "
-          import re, sys
-          m = re.search(r'version\s*=\s*\"([^\"]+)\"', open('pyproject.toml').read())
-          print(m.group(1) if m else sys.exit(1))
-          ")
-          echo "Current version: $CURRENT"
+          # Read current version from last vX.Y.Z tag (not pyproject.toml)
+          CURRENT=$(git describe --tags --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*" 2>/dev/null | sed 's/^v//')
+          if [ -z "$CURRENT" ]; then
+            CURRENT="0.0.0"
+          fi
+          echo "Current version (last tag): $CURRENT"
 
           MAJOR=$(echo $CURRENT | cut -d. -f1)
           MINOR=$(echo $CURRENT | cut -d. -f2)
           PATCH=$(echo $CURRENT | cut -d. -f3)
 
-          # MAJOR: breaking change marker
           if echo "$COMMIT_MSG" | grep -qE "(^(feat|fix|refactor|perf)!:)|(BREAKING CHANGE:)"; then
             BUMP=major
             MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
-          # MINOR: new feature
           elif echo "$COMMIT_MSG" | grep -qE "^feat(\([^)]+\))?:"; then
             BUMP=minor
             MINOR=$((MINOR + 1)); PATCH=0
-          # PATCH: bug fix or improvement
           elif echo "$COMMIT_MSG" | grep -qE "^(fix|perf|refactor)(\([^)]+\))?:"; then
             BUMP=patch
             PATCH=$((PATCH + 1))
-          # No release: maintenance commits
           else
             echo "Commit type does not trigger a release (docs/chore/style/ci/test). Skipping."
             echo "skip=true" >> $GITHUB_OUTPUT
@@ -64,23 +59,13 @@ jobs:
           echo "bump=$BUMP"       >> $GITHUB_OUTPUT
           echo "skip=false"       >> $GITHUB_OUTPUT
 
-      # ── Update pyproject.toml ───────────────────────────────────────────
-      - name: Update version in pyproject.toml
-        if: steps.version.outputs.skip != 'true'
-        run: |
-          sed -i "s/^version *= *\"${{ steps.version.outputs.current }}\"/version = \"${{ steps.version.outputs.new }}\"/" pyproject.toml
-          grep "^version" pyproject.toml
-
-      # ── Commit, tag, push ───────────────────────────────────────────────
-      - name: Commit version bump and tag
+      # ── Tag and push (no pyproject.toml commit needed) ──────────────────
+      - name: Create and push release tag
         if: steps.version.outputs.skip != 'true'
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          git commit -m "chore: release v${{ steps.version.outputs.new }} [skip ci]"
           git tag "v${{ steps.version.outputs.new }}"
-          git push origin main
           git push origin "v${{ steps.version.outputs.new }}"
 
       # ── Build wheel + sdist ─────────────────────────────────────────────
@@ -97,31 +82,48 @@ jobs:
           python -m build
           ls dist/
 
+      # ── Generate changelog with git-cliff ──────────────────────────────
+      - name: Install git-cliff
+        if: steps.version.outputs.skip != 'true'
+        run: pip install git-cliff
+
+      - name: Generate release notes
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          git cliff --latest --strip all 2>/dev/null > /tmp/cliff_body.md
+          if [ ! -s /tmp/cliff_body.md ]; then
+            echo "No user-facing changes in this release." > /tmp/cliff_body.md
+          fi
+
+          cat > /tmp/release_notes.md <<HEADER
+          ## Something X v${{ steps.version.outputs.new }}
+
+          HEADER
+          cat /tmp/cliff_body.md >> /tmp/release_notes.md
+          cat >> /tmp/release_notes.md <<'FOOTER'
+
+          ### Install
+
+          ```bash
+          # Arch / Omarchy (recommended)
+          sudo pacman -S python-gobject python-cairo gtk4 libadwaita
+          pip install something-x==${{ steps.version.outputs.new }}
+
+          # Or download the wheel below
+          pip install something_x-${{ steps.version.outputs.new }}-py3-none-any.whl
+          ```
+          FOOTER
+
       # ── GitHub Release ──────────────────────────────────────────────────
       - name: Create GitHub Release
         if: steps.version.outputs.skip != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: "v${{ steps.version.outputs.new }}"
-          generate_release_notes: true
+          body_path: /tmp/release_notes.md
           files: dist/*
-          body: |
-            ## Something X v${{ steps.version.outputs.new }}
 
-            **Bump type**: `${{ steps.version.outputs.bump }}`
-
-            ### Install
-
-            ```bash
-            # Arch / Omarchy (recommended)
-            sudo pacman -S python-gobject python-dbus python-cairo gtk4 libadwaita
-            pip install something-x==${{ steps.version.outputs.new }}
-
-            # Or download the wheel below and install directly
-            pip install something_x-${{ steps.version.outputs.new }}-py3-none-any.whl
-            ```
-
-      # ── Publish to PyPI (OIDC trusted publisher — no secret needed) ─────
+      # ── Publish to PyPI (OIDC trusted publisher) ────────────────────────
       - name: Publish to PyPI
         if: steps.version.outputs.skip != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -133,8 +135,6 @@ jobs:
           NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
           SHA256=$(sha256sum dist/something_x-${NEW_VERSION}.tar.gz | awk '{print $1}')
-          echo "sha256: $SHA256"
-
           sed -i "s/^pkgver=.*/pkgver=${NEW_VERSION}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
           sed -i "s/sha256sums=('[^']*')/sha256sums=('${SHA256}')/" PKGBUILD

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ ENV/
 .DS_Store
 Thumbs.db
 
+# setuptools-scm generated version file (written at install/build time)
+nothing_app/_version.py
+
 # APK reverse-engineering artifacts (local research only)
 *apkm*
 apkm_decompiled/

--- a/nothing_app/__init__.py
+++ b/nothing_app/__init__.py
@@ -1,2 +1,20 @@
-__version__ = "1.0.0"
+from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PNF
+
+
+def _resolve_version() -> str:
+    for pkg in ("something-x", "something-x-dev"):
+        try:
+            return _pkg_version(pkg)
+        except _PNF:
+            pass
+    # Running from source: setuptools-scm writes _version.py at build/install time
+    try:
+        from ._version import __version__
+
+        return __version__
+    except ImportError:
+        return "0.0.0+dev"
+
+
+__version__ = _resolve_version()
 APP_ID = "com.something.x.omarchy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=64", "wheel", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name            = "something-x"
-version = "1.6.0"
+dynamic         = ["version"]
 description     = "Something X device manager for Omarchy / Linux"
 readme          = "README.md"
 license         = { text = "MIT" }
@@ -42,6 +42,13 @@ nothing_app = ["data/*.css", "data/*.desktop"]
 
 [project.optional-dependencies]
 dev = ["ruff"]
+
+[tool.setuptools_scm]
+# After tag v1.7.0, develop automatically produces 1.7.1.devN (N = commits since tag).
+# Strips the local +gHASH so PyPI accepts the version.
+version_scheme = "guess-next-dev"
+local_scheme   = "no-local-version"
+version_file   = "nothing_app/_version.py"
 
 [tool.ruff]
 line-length = 110


### PR DESCRIPTION
Version is now computed from git tags at build time.
- After tag v1.7.0, develop automatically produces 1.7.1.devN
- release.yml reads the last vX.Y.Z tag instead of pyproject.toml; drops the version-bump commit (just creates the tag directly)
- release-dev.yml only patches the package name; setuptools-scm handles the version automatically
- __init__.py resolves version via importlib.metadata with a fallback to the setuptools-scm generated _version.py for source runs
- _version.py is gitignored (generated at install/build time)