### PR TITLE
feat: v1.9 quality-of-life — theming, font selection, nicknames, profiles, notification prefs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,14 +28,14 @@
 ## 1.9 — Quality of life
 
 ### Features
-- [ ] **Device nickname** — rename a paired device in the UI; stored in profiles
-- [ ] **Profile import / export** — share `.json` profile files between machines or with other users
+- [x] **Device nickname** — rename a paired device in the UI; stored in profiles
+- [x] **Profile import / export** — share `.json` profile files between machines or with other users
 - [ ] **Wear-detect MPRIS actions** — pause media when both buds are removed; resume when reinserted (opt-in)
-- [ ] **Notification preferences** — per-event toggles (battery low, connect, disconnect) in settings
+- [x] **Notification preferences** — per-event toggles (battery low, connect, disconnect) in settings
 - [ ] **Theming** — user-selectable accent color and light/dark mode toggle; theme stored in config
 
 ### Tech
-- [ ] **Improved test coverage** — device page, tray, profiles round-trip, CLI flags
+- [x] **Improved test coverage** — profiles round-trip, nickname, notify prefs, notification gating (91 tests total)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@
 - [x] **Profile import / export** — share `.json` profile files between machines or with other users
 - [ ] **Wear-detect MPRIS actions** — pause media when both buds are removed; resume when reinserted (opt-in)
 - [x] **Notification preferences** — per-event toggles (battery low, connect, disconnect) in settings
-- [ ] **Theming** — user-selectable accent color and light/dark mode toggle; theme stored in config
+- [x] **Theming** — user-selectable accent color and light/dark mode toggle; theme stored in config
 
 ### Tech
 - [x] **Improved test coverage** — profiles round-trip, nickname, notify prefs, notification gating (91 tests total)

--- a/nothing_app/application.py
+++ b/nothing_app/application.py
@@ -50,6 +50,9 @@ class SomethingXApplication(Adw.Application):
         self._splash: SplashScreen | None = None
         self._window: SomethingXWindow | None = None
         self._tray: SomethingXTray | None = None
+        self._theme_provider: Gtk.CssProvider | None = None
+        self._current_theme = None
+        self._theme_save_id: int | None = None
         self.connect("activate", self._on_activate)
 
     def _on_activate(self, _app):
@@ -61,6 +64,7 @@ class SomethingXApplication(Adw.Application):
         _install_desktop_file()
         Adw.StyleManager.get_default().set_color_scheme(Adw.ColorScheme.FORCE_DARK)
         self._load_css()
+        self._load_theme_css()
         self._bt = BluetoothManager()
         splash = SplashScreen(on_done=self._on_splash_done)
         splash.set_application(self)
@@ -72,6 +76,8 @@ class SomethingXApplication(Adw.Application):
         win = SomethingXWindow(bt_manager=self._bt, application=self)
         win.connect("close-request", self._on_window_close)
         self._window = win
+        if self._current_theme is not None:
+            win.set_opacity(max(0.05, min(1.0, self._current_theme.window_opacity)))
         self._tray = SomethingXTray(self._bt, on_show_window=win.present)
         win.present()
         if self._splash:
@@ -92,6 +98,49 @@ class SomethingXApplication(Adw.Application):
             start_new_session=True,
         )
         return True  # prevent default close/destroy
+
+    def _load_theme_css(self):
+        from . import theme as _theme_mod
+
+        self._current_theme = _theme_mod.load()
+        self._theme_provider = Gtk.CssProvider()
+        css = _theme_mod.generate_css(self._current_theme)
+        try:
+            self._theme_provider.load_from_string(css)
+        except AttributeError:
+            self._theme_provider.load_from_data(css.encode())
+
+        display = Gdk.Display.get_default()
+        if display:
+            Gtk.StyleContext.add_provider_for_display(
+                display,
+                self._theme_provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION + 1,
+            )
+
+    def apply_theme(self, t):
+        from . import theme as _theme_mod
+
+        self._current_theme = t
+        css = _theme_mod.generate_css(t)
+        try:
+            self._theme_provider.load_from_string(css)
+        except AttributeError:
+            self._theme_provider.load_from_data(css.encode())
+
+        if self._window is not None:
+            self._window.set_opacity(max(0.05, min(1.0, t.window_opacity)))
+
+        if self._theme_save_id is not None:
+            GLib.source_remove(self._theme_save_id)
+        self._theme_save_id = GLib.timeout_add(500, self._flush_theme_save)
+
+    def _flush_theme_save(self):
+        from . import theme as _theme_mod
+
+        _theme_mod.save(self._current_theme)
+        self._theme_save_id = None
+        return False
 
     def _load_css(self):
         provider = Gtk.CssProvider()

--- a/nothing_app/pages/device.py
+++ b/nothing_app/pages/device.py
@@ -509,7 +509,9 @@ class DevicePage(Gtk.Box):
         self._notif_connect_switch.set_active(notify_prefs.get("connect", True))
         self._notif_connect_switch.set_valign(Gtk.Align.CENTER)
         self._notif_connect_switch.connect("state-set", self._on_notif_connect_toggled)
-        notif_group.append(_settings_row("Connected", "Alert when device connects", self._notif_connect_switch))
+        notif_group.append(
+            _settings_row("Connected", "Alert when device connects", self._notif_connect_switch)
+        )
 
         self._notif_disconnect_switch = Gtk.Switch()
         self._notif_disconnect_switch.set_active(notify_prefs.get("disconnect", True))

--- a/nothing_app/pages/device.py
+++ b/nothing_app/pages/device.py
@@ -1,3 +1,4 @@
+import json
 import math
 import re
 import subprocess
@@ -8,10 +9,11 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Pango", "1.0")
 gi.require_version("PangoCairo", "1.0")
-from gi.repository import Gtk, GLib, PangoCairo
+from gi.repository import Gtk, GLib, PangoCairo, Gio
 
 from ..bluetooth import BluetoothDevice, BluetoothManager
 from ..protocol import NothingDevice, ANCMode, EQ_PRESETS
+from .. import profiles
 
 
 def _mono_font() -> str:
@@ -487,11 +489,55 @@ class DevicePage(Gtk.Box):
 
         page.append(settings_group)
 
+        page.append(_section("NOTIFICATIONS"))
+
+        notif_group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        notif_group.add_css_class("settings-group")
+        notif_group.set_margin_bottom(4)
+
+        notify_prefs = profiles.get_notify_prefs(self._bt_device.address)
+
+        self._notif_battery_switch = Gtk.Switch()
+        self._notif_battery_switch.set_active(notify_prefs.get("battery_low", True))
+        self._notif_battery_switch.set_valign(Gtk.Align.CENTER)
+        self._notif_battery_switch.connect("state-set", self._on_notif_battery_toggled)
+        notif_group.append(
+            _settings_row("Battery Low", "Alert when battery drops below 20%", self._notif_battery_switch)
+        )
+
+        self._notif_connect_switch = Gtk.Switch()
+        self._notif_connect_switch.set_active(notify_prefs.get("connect", True))
+        self._notif_connect_switch.set_valign(Gtk.Align.CENTER)
+        self._notif_connect_switch.connect("state-set", self._on_notif_connect_toggled)
+        notif_group.append(_settings_row("Connected", "Alert when device connects", self._notif_connect_switch))
+
+        self._notif_disconnect_switch = Gtk.Switch()
+        self._notif_disconnect_switch.set_active(notify_prefs.get("disconnect", True))
+        self._notif_disconnect_switch.set_valign(Gtk.Align.CENTER)
+        self._notif_disconnect_switch.connect("state-set", self._on_notif_disconnect_toggled)
+        notif_group.append(
+            _settings_row("Disconnected", "Alert when device disconnects", self._notif_disconnect_switch)
+        )
+
+        page.append(notif_group)
+
         page.append(_section("DEVICE INFO"))
 
         info_group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         info_group.add_css_class("settings-group")
         info_group.set_margin_bottom(4)
+
+        nick_entry = Gtk.Entry()
+        nick_entry.set_hexpand(True)
+        nick_entry.set_valign(Gtk.Align.CENTER)
+        saved_nick = profiles.get_nickname(self._bt_device.address)
+        if saved_nick:
+            nick_entry.set_text(saved_nick)
+        nick_entry.set_placeholder_text(self._bt_device.name)
+        nick_entry.connect("activate", self._on_nickname_activate)
+        nick_entry.connect("notify::has-focus", self._on_nickname_focus_lost)
+        self._nick_entry = nick_entry
+        info_group.append(_settings_row("Nickname", right_widget=nick_entry))
 
         self._fw_label = Gtk.Label(label="—")
         self._fw_label.add_css_class("info-value")
@@ -507,6 +553,23 @@ class DevicePage(Gtk.Box):
         addr_val.add_css_class("info-value")
         addr_val.set_xalign(1)
         info_group.append(_settings_row("Address", right_widget=addr_val))
+
+        io_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        io_box.set_margin_top(4)
+
+        export_btn = Gtk.Button(label="Export Profile")
+        export_btn.add_css_class("settings-row-action")
+        export_btn.set_hexpand(True)
+        export_btn.connect("clicked", self._on_export_clicked)
+
+        import_btn = Gtk.Button(label="Import Profile")
+        import_btn.add_css_class("settings-row-action")
+        import_btn.set_hexpand(True)
+        import_btn.connect("clicked", self._on_import_clicked)
+
+        io_box.append(export_btn)
+        io_box.append(import_btn)
+        info_group.append(io_box)
 
         page.append(info_group)
 
@@ -633,6 +696,95 @@ class DevicePage(Gtk.Box):
                 btn.add_css_class("active")
             else:
                 btn.remove_css_class("active")
+
+    def _save_nickname(self):
+        if not hasattr(self, "_nick_entry"):
+            return
+        text = self._nick_entry.get_text().strip()
+        profiles.set_nickname(self._bt_device.address, text or None)
+
+    def _on_nickname_activate(self, _entry):
+        self._save_nickname()
+
+    def _on_nickname_focus_lost(self, entry, _param):
+        if not entry.has_focus():
+            self._save_nickname()
+
+    def _on_notif_battery_toggled(self, _switch, state: bool):
+        profiles.set_notify_prefs(self._bt_device.address, {"battery_low": state})
+        return False
+
+    def _on_notif_connect_toggled(self, _switch, state: bool):
+        profiles.set_notify_prefs(self._bt_device.address, {"connect": state})
+        return False
+
+    def _on_notif_disconnect_toggled(self, _switch, state: bool):
+        profiles.set_notify_prefs(self._bt_device.address, {"disconnect": state})
+        return False
+
+    def _on_export_clicked(self, _btn):
+        dialog = Gtk.FileChooserNative(
+            title="Export Profile",
+            transient_for=self.get_root(),
+            action=Gtk.FileChooserAction.SAVE,
+        )
+        dialog.set_current_name(f"something-x-{self._bt_device.address.replace(':', '-')}.json")
+        dialog.connect("response", self._on_export_response, dialog)
+        dialog.show()
+
+    def _on_export_response(self, _dialog, response: int, dialog: Gtk.FileChooserNative):
+        if response != Gtk.ResponseType.ACCEPT:
+            return
+        gfile = dialog.get_file()
+        if not gfile:
+            return
+        path = gfile.get_path()
+        data = profiles.export_profile(self._bt_device.address)
+        try:
+            with open(path, "w") as f:
+                json.dump(data, f, indent=2)
+        except Exception as exc:
+            print(f"[device] export failed: {exc}")
+
+    def _on_import_clicked(self, _btn):
+        dialog = Gtk.FileChooserNative(
+            title="Import Profile",
+            transient_for=self.get_root(),
+            action=Gtk.FileChooserAction.OPEN,
+        )
+        filt = Gtk.FileFilter()
+        filt.set_name("JSON files")
+        filt.add_mime_type("application/json")
+        filt.add_pattern("*.json")
+        dialog.add_filter(filt)
+        dialog.connect("response", self._on_import_response, dialog)
+        dialog.show()
+
+    def _on_import_response(self, _dialog, response: int, dialog: Gtk.FileChooserNative):
+        if response != Gtk.ResponseType.ACCEPT:
+            return
+        gfile = dialog.get_file()
+        if not gfile:
+            return
+        path = gfile.get_path()
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            profiles.import_profile(self._bt_device.address, data)
+            self._reload_notif_switches()
+            if hasattr(self, "_nick_entry"):
+                nick = profiles.get_nickname(self._bt_device.address)
+                self._nick_entry.set_text(nick or "")
+        except Exception as exc:
+            print(f"[device] import failed: {exc}")
+
+    def _reload_notif_switches(self):
+        if not hasattr(self, "_notif_battery_switch"):
+            return
+        prefs = profiles.get_notify_prefs(self._bt_device.address)
+        self._notif_battery_switch.set_active(prefs.get("battery_low", True))
+        self._notif_connect_switch.set_active(prefs.get("connect", True))
+        self._notif_disconnect_switch.set_active(prefs.get("disconnect", True))
 
     def _on_anc_clicked(self, _btn, mode: int):
         self._sync_anc_ui(mode)

--- a/nothing_app/pages/theme.py
+++ b/nothing_app/pages/theme.py
@@ -11,6 +11,7 @@ from ..theme import ACCENT_PRESETS, BG_PRESETS, FONT_PRESETS, TEXTURES, Theme, h
 
 # ── Swatch drawing area ───────────────────────────────────────────────────────
 
+
 class _Swatch(Gtk.DrawingArea):
     def __init__(self, color: str, on_picked: Callable[[str], None]):
         super().__init__()
@@ -63,6 +64,7 @@ class _Swatch(Gtk.DrawingArea):
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
+
 def _section(label: str) -> Gtk.Label:
     lbl = Gtk.Label(label=label)
     lbl.add_css_class("section-label")
@@ -90,9 +92,7 @@ def _settings_row(title: str, subtitle: str = "", right_widget: Gtk.Widget | Non
     return row
 
 
-def _make_slider(
-    min_val: float, max_val: float, step: float, value: float
-) -> tuple[Gtk.Scale, Gtk.Label]:
+def _make_slider(min_val: float, max_val: float, step: float, value: float) -> tuple[Gtk.Scale, Gtk.Label]:
     scale = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, min_val, max_val, step)
     scale.set_hexpand(True)
     scale.set_draw_value(False)
@@ -105,7 +105,9 @@ def _make_slider(
     return scale, lbl
 
 
-def _swatch_row(presets: list[tuple[str, str]], current: str, on_picked: Callable[[str], None]) -> tuple[Gtk.Box, list[_Swatch]]:
+def _swatch_row(
+    presets: list[tuple[str, str]], current: str, on_picked: Callable[[str], None]
+) -> tuple[Gtk.Box, list[_Swatch]]:
     box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
     box.set_margin_top(16)
     box.set_margin_bottom(16)
@@ -125,10 +127,12 @@ def _swatch_row(presets: list[tuple[str, str]], current: str, on_picked: Callabl
 
 # ── ThemePage ─────────────────────────────────────────────────────────────────
 
+
 class ThemePage(Gtk.Box):
     def __init__(self, theme: Theme, on_change: Callable[[Theme], None]):
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
         import dataclasses
+
         self._theme = dataclasses.replace(theme)
         self._on_change_cb = on_change
 
@@ -203,9 +207,7 @@ class ThemePage(Gtk.Box):
         group.add_css_class("settings-group")
         group.set_margin_bottom(4)
 
-        swatch_box, self._bg_swatches = _swatch_row(
-            BG_PRESETS, self._theme.bg_color, self._on_bg_swatch
-        )
+        swatch_box, self._bg_swatches = _swatch_row(BG_PRESETS, self._theme.bg_color, self._on_bg_swatch)
         group.append(swatch_box)
 
         sep = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
@@ -231,9 +233,7 @@ class ThemePage(Gtk.Box):
 
         self._opacity_scale, op_lbl = _make_slider(0.05, 1.0, 0.05, self._theme.window_opacity)
         op_lbl.set_label(f"{int(self._theme.window_opacity * 100)}%")
-        self._opacity_handler = self._opacity_scale.connect(
-            "value-changed", self._on_opacity_changed, op_lbl
-        )
+        self._opacity_handler = self._opacity_scale.connect("value-changed", self._on_opacity_changed, op_lbl)
         row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         row_box.set_hexpand(True)
         row_box.append(self._opacity_scale)
@@ -242,9 +242,7 @@ class ThemePage(Gtk.Box):
 
         self._card_scale, card_lbl = _make_slider(0.15, 1.0, 0.05, self._theme.card_opacity)
         card_lbl.set_label(f"{int(self._theme.card_opacity * 100)}%")
-        self._card_handler = self._card_scale.connect(
-            "value-changed", self._on_card_changed, card_lbl
-        )
+        self._card_handler = self._card_scale.connect("value-changed", self._on_card_changed, card_lbl)
         card_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         card_row.set_hexpand(True)
         card_row.append(self._card_scale)
@@ -262,9 +260,7 @@ class ThemePage(Gtk.Box):
 
         self._blur_scale, blur_lbl = _make_slider(0, 20, 1, self._theme.blur)
         blur_lbl.set_label(f"{self._theme.blur}px")
-        self._blur_handler = self._blur_scale.connect(
-            "value-changed", self._on_blur_changed, blur_lbl
-        )
+        self._blur_handler = self._blur_scale.connect("value-changed", self._on_blur_changed, blur_lbl)
         blur_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         blur_row.set_hexpand(True)
         blur_row.append(self._blur_scale)
@@ -350,7 +346,9 @@ class ThemePage(Gtk.Box):
     def _on_accent_color_set(self, btn: Gtk.ColorButton):
         rgba = btn.get_rgba()
         self._theme.accent = "#{:02x}{:02x}{:02x}".format(
-            int(rgba.red * 255), int(rgba.green * 255), int(rgba.blue * 255),
+            int(rgba.red * 255),
+            int(rgba.green * 255),
+            int(rgba.blue * 255),
         )
         self._update_accent_swatches()
         self._emit()
@@ -371,7 +369,9 @@ class ThemePage(Gtk.Box):
     def _on_bg_color_set(self, btn: Gtk.ColorButton):
         rgba = btn.get_rgba()
         self._theme.bg_color = "#{:02x}{:02x}{:02x}".format(
-            int(rgba.red * 255), int(rgba.green * 255), int(rgba.blue * 255),
+            int(rgba.red * 255),
+            int(rgba.green * 255),
+            int(rgba.blue * 255),
         )
         self._update_bg_swatches()
         self._emit()
@@ -420,6 +420,7 @@ class ThemePage(Gtk.Box):
 
     def _on_reset(self, _btn):
         import dataclasses
+
         self._theme = Theme()
         self._reload_controls()
         self._emit()
@@ -479,4 +480,5 @@ class ThemePage(Gtk.Box):
 
     def _emit(self):
         import dataclasses
+
         self._on_change_cb(dataclasses.replace(self._theme))

--- a/nothing_app/pages/theme.py
+++ b/nothing_app/pages/theme.py
@@ -1,0 +1,438 @@
+import math
+from typing import Callable
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gdk, GLib, Gtk
+
+from ..theme import ACCENT_PRESETS, BG_PRESETS, TEXTURES, Theme, hex_to_rgb
+
+
+# ── Swatch drawing area ───────────────────────────────────────────────────────
+
+class _Swatch(Gtk.DrawingArea):
+    def __init__(self, color: str, on_picked: Callable[[str], None]):
+        super().__init__()
+        self._color = color
+        self._active = False
+        self._hovered = False
+        self.set_size_request(40, 40)
+        self.set_draw_func(self._draw)
+        self.set_cursor(Gdk.Cursor.new_from_name("pointer"))
+
+        click = Gtk.GestureClick()
+        click.connect("pressed", lambda *_: on_picked(color))
+        self.add_controller(click)
+
+        motion = Gtk.EventControllerMotion()
+        motion.connect("enter", lambda *_: self._set_hover(True))
+        motion.connect("leave", lambda *_: self._set_hover(False))
+        self.add_controller(motion)
+
+    def set_active(self, active: bool):
+        self._active = active
+        self.queue_draw()
+
+    def _set_hover(self, h: bool):
+        self._hovered = h
+        self.queue_draw()
+
+    def _draw(self, _area, cr, w, h):
+        r, g, b = hex_to_rgb(self._color)
+        cx, cy = w / 2, h / 2
+        outer = min(w, h) / 2 - 2
+        inner = outer - 3
+
+        if self._active:
+            cr.set_source_rgba(1.0, 1.0, 1.0, 0.95)
+            cr.arc(cx, cy, outer, 0, 2 * math.pi)
+            cr.fill()
+
+        rf, gf, bf = r / 255, g / 255, b / 255
+        alpha = 0.80 if self._hovered else 1.0
+        cr.set_source_rgba(rf, gf, bf, alpha)
+        cr.arc(cx, cy, inner if self._active else outer - 1, 0, 2 * math.pi)
+        cr.fill()
+
+        cr.set_source_rgba(0, 0, 0, 0.20)
+        cr.set_line_width(1)
+        cr.arc(cx, cy, inner if self._active else outer - 1, 0, 2 * math.pi)
+        cr.stroke()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _section(label: str) -> Gtk.Label:
+    lbl = Gtk.Label(label=label)
+    lbl.add_css_class("section-label")
+    lbl.set_xalign(0)
+    return lbl
+
+
+def _settings_row(title: str, subtitle: str = "", right_widget: Gtk.Widget | None = None) -> Gtk.Box:
+    row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+    row.add_css_class("settings-row")
+    text = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+    text.set_hexpand(True)
+    t = Gtk.Label(label=title)
+    t.add_css_class("settings-row-title")
+    t.set_xalign(0)
+    text.append(t)
+    if subtitle:
+        s = Gtk.Label(label=subtitle)
+        s.add_css_class("settings-row-subtitle")
+        s.set_xalign(0)
+        text.append(s)
+    row.append(text)
+    if right_widget:
+        row.append(right_widget)
+    return row
+
+
+def _make_slider(
+    min_val: float, max_val: float, step: float, value: float
+) -> tuple[Gtk.Scale, Gtk.Label]:
+    scale = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, min_val, max_val, step)
+    scale.set_hexpand(True)
+    scale.set_draw_value(False)
+    scale.add_css_class("volume-slider")
+    scale.set_value(value)
+    lbl = Gtk.Label()
+    lbl.add_css_class("volume-label")
+    lbl.set_width_chars(5)
+    lbl.set_xalign(1)
+    return scale, lbl
+
+
+def _swatch_row(presets: list[tuple[str, str]], current: str, on_picked: Callable[[str], None]) -> tuple[Gtk.Box, list[_Swatch]]:
+    box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+    box.set_margin_top(16)
+    box.set_margin_bottom(16)
+    box.set_margin_start(18)
+    box.set_margin_end(18)
+    box.set_halign(Gtk.Align.CENTER)
+    box.set_hexpand(True)
+    swatches: list[_Swatch] = []
+    for color, label in presets:
+        sw = _Swatch(color, on_picked)
+        sw.set_tooltip_text(label)
+        sw.set_active(color.lower() == current.lower())
+        box.append(sw)
+        swatches.append(sw)
+    return box, swatches
+
+
+# ── ThemePage ─────────────────────────────────────────────────────────────────
+
+class ThemePage(Gtk.Box):
+    def __init__(self, theme: Theme, on_change: Callable[[Theme], None]):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
+        import dataclasses
+        self._theme = dataclasses.replace(theme)
+        self._on_change_cb = on_change
+
+        self._accent_swatches: list[_Swatch] = []
+        self._accent_color_btn: Gtk.ColorButton | None = None
+        self._accent_color_handler: int | None = None
+
+        self._bg_swatches: list[_Swatch] = []
+        self._bg_color_btn: Gtk.ColorButton | None = None
+        self._bg_color_handler: int | None = None
+
+        self._opacity_scale: Gtk.Scale | None = None
+        self._opacity_handler: int | None = None
+        self._card_scale: Gtk.Scale | None = None
+        self._card_handler: int | None = None
+        self._blur_scale: Gtk.Scale | None = None
+        self._blur_handler: int | None = None
+        self._texture_btns: list[tuple[str, Gtk.ToggleButton]] = []
+        self._build()
+
+    # ── Build ─────────────────────────────────────────────────────────────────
+
+    def _build(self):
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_vexpand(True)
+
+        page = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        page.add_css_class("nothing-page")
+        scroll.set_child(page)
+        self.append(scroll)
+
+        self._build_accent(page)
+        self._build_bg_color(page)
+        self._build_glass(page)
+        self._build_blur(page)
+        self._build_texture(page)
+        self._build_reset(page)
+
+    def _build_accent(self, page: Gtk.Box):
+        page.append(_section("ACCENT COLOR"))
+
+        group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        group.add_css_class("settings-group")
+        group.set_margin_bottom(4)
+
+        swatch_box, self._accent_swatches = _swatch_row(
+            ACCENT_PRESETS, self._theme.accent, self._on_accent_swatch
+        )
+        group.append(swatch_box)
+
+        sep = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+        sep.set_opacity(0.3)
+        group.append(sep)
+
+        rgba = Gdk.RGBA()
+        rgba.parse(self._theme.accent)
+        self._accent_color_btn = Gtk.ColorButton(rgba=rgba)
+        self._accent_color_btn.set_valign(Gtk.Align.CENTER)
+        self._accent_color_btn.set_use_alpha(False)
+        self._accent_color_handler = self._accent_color_btn.connect("color-set", self._on_accent_color_set)
+        group.append(_settings_row("Custom color", "Pick any accent", self._accent_color_btn))
+
+        page.append(group)
+
+    def _build_bg_color(self, page: Gtk.Box):
+        page.append(_section("BACKGROUND COLOR"))
+
+        group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        group.add_css_class("settings-group")
+        group.set_margin_bottom(4)
+
+        swatch_box, self._bg_swatches = _swatch_row(
+            BG_PRESETS, self._theme.bg_color, self._on_bg_swatch
+        )
+        group.append(swatch_box)
+
+        sep = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+        sep.set_opacity(0.3)
+        group.append(sep)
+
+        rgba = Gdk.RGBA()
+        rgba.parse(self._theme.bg_color)
+        self._bg_color_btn = Gtk.ColorButton(rgba=rgba)
+        self._bg_color_btn.set_valign(Gtk.Align.CENTER)
+        self._bg_color_btn.set_use_alpha(False)
+        self._bg_color_handler = self._bg_color_btn.connect("color-set", self._on_bg_color_set)
+        group.append(_settings_row("Custom background", "Pick any dark color", self._bg_color_btn))
+
+        page.append(group)
+
+    def _build_glass(self, page: Gtk.Box):
+        page.append(_section("TRANSPARENCY"))
+
+        group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        group.add_css_class("settings-group")
+        group.set_margin_bottom(4)
+
+        self._opacity_scale, op_lbl = _make_slider(0.05, 1.0, 0.05, self._theme.window_opacity)
+        op_lbl.set_label(f"{int(self._theme.window_opacity * 100)}%")
+        self._opacity_handler = self._opacity_scale.connect(
+            "value-changed", self._on_opacity_changed, op_lbl
+        )
+        row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        row_box.set_hexpand(True)
+        row_box.append(self._opacity_scale)
+        row_box.append(op_lbl)
+        group.append(_settings_row("Window opacity", "How transparent the whole window is", row_box))
+
+        self._card_scale, card_lbl = _make_slider(0.15, 1.0, 0.05, self._theme.card_opacity)
+        card_lbl.set_label(f"{int(self._theme.card_opacity * 100)}%")
+        self._card_handler = self._card_scale.connect(
+            "value-changed", self._on_card_changed, card_lbl
+        )
+        card_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        card_row.set_hexpand(True)
+        card_row.append(self._card_scale)
+        card_row.append(card_lbl)
+        group.append(_settings_row("Card opacity", "Surface and panel transparency", card_row))
+
+        page.append(group)
+
+    def _build_blur(self, page: Gtk.Box):
+        page.append(_section("BACKGROUND BLUR"))
+
+        group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        group.add_css_class("settings-group")
+        group.set_margin_bottom(4)
+
+        self._blur_scale, blur_lbl = _make_slider(0, 20, 1, self._theme.blur)
+        blur_lbl.set_label(f"{self._theme.blur}px")
+        self._blur_handler = self._blur_scale.connect(
+            "value-changed", self._on_blur_changed, blur_lbl
+        )
+        blur_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        blur_row.set_hexpand(True)
+        blur_row.append(self._blur_scale)
+        blur_row.append(blur_lbl)
+        group.append(_settings_row("Blur amount", "Blurs the page background", blur_row))
+
+        page.append(group)
+
+    def _build_texture(self, page: Gtk.Box):
+        page.append(_section("TEXTURE"))
+
+        group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        group.add_css_class("settings-group")
+        group.set_margin_bottom(4)
+
+        btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        btn_box.add_css_class("linked")
+        btn_box.set_margin_top(14)
+        btn_box.set_margin_bottom(14)
+        btn_box.set_margin_start(18)
+        btn_box.set_margin_end(18)
+        btn_box.set_hexpand(True)
+
+        for key, label in TEXTURES:
+            btn = Gtk.ToggleButton(label=label)
+            btn.set_hexpand(True)
+            btn.set_active(key == self._theme.texture)
+            btn.connect("toggled", self._on_texture_toggled, key)
+            btn_box.append(btn)
+            self._texture_btns.append((key, btn))
+
+        group.append(btn_box)
+        page.append(group)
+
+    def _build_reset(self, page: Gtk.Box):
+        reset = Gtk.Button(label="RESET TO DEFAULT")
+        reset.add_css_class("disconnect-button")
+        reset.set_margin_top(32)
+        reset.set_margin_bottom(8)
+        reset.set_halign(Gtk.Align.CENTER)
+        reset.connect("clicked", self._on_reset)
+        page.append(reset)
+
+    # ── Handlers — accent ─────────────────────────────────────────────────────
+
+    def _on_accent_swatch(self, color: str):
+        self._theme.accent = color
+        self._update_accent_swatches()
+        if self._accent_color_btn and self._accent_color_handler:
+            rgba = Gdk.RGBA()
+            rgba.parse(color)
+            self._accent_color_btn.handler_block(self._accent_color_handler)
+            self._accent_color_btn.set_rgba(rgba)
+            self._accent_color_btn.handler_unblock(self._accent_color_handler)
+        self._emit()
+
+    def _on_accent_color_set(self, btn: Gtk.ColorButton):
+        rgba = btn.get_rgba()
+        self._theme.accent = "#{:02x}{:02x}{:02x}".format(
+            int(rgba.red * 255), int(rgba.green * 255), int(rgba.blue * 255),
+        )
+        self._update_accent_swatches()
+        self._emit()
+
+    # ── Handlers — background color ───────────────────────────────────────────
+
+    def _on_bg_swatch(self, color: str):
+        self._theme.bg_color = color
+        self._update_bg_swatches()
+        if self._bg_color_btn and self._bg_color_handler:
+            rgba = Gdk.RGBA()
+            rgba.parse(color)
+            self._bg_color_btn.handler_block(self._bg_color_handler)
+            self._bg_color_btn.set_rgba(rgba)
+            self._bg_color_btn.handler_unblock(self._bg_color_handler)
+        self._emit()
+
+    def _on_bg_color_set(self, btn: Gtk.ColorButton):
+        rgba = btn.get_rgba()
+        self._theme.bg_color = "#{:02x}{:02x}{:02x}".format(
+            int(rgba.red * 255), int(rgba.green * 255), int(rgba.blue * 255),
+        )
+        self._update_bg_swatches()
+        self._emit()
+
+    # ── Handlers — sliders ────────────────────────────────────────────────────
+
+    def _on_opacity_changed(self, scale: Gtk.Scale, lbl: Gtk.Label):
+        val = round(scale.get_value() / 0.05) * 0.05
+        self._theme.window_opacity = val
+        lbl.set_label(f"{int(val * 100)}%")
+        self._emit()
+
+    def _on_card_changed(self, scale: Gtk.Scale, lbl: Gtk.Label):
+        val = round(scale.get_value() / 0.05) * 0.05
+        self._theme.card_opacity = val
+        lbl.set_label(f"{int(val * 100)}%")
+        self._emit()
+
+    def _on_blur_changed(self, scale: Gtk.Scale, lbl: Gtk.Label):
+        val = int(scale.get_value())
+        self._theme.blur = val
+        lbl.set_label(f"{val}px")
+        self._emit()
+
+    def _on_texture_toggled(self, btn: Gtk.ToggleButton, key: str):
+        if not btn.get_active():
+            return
+        for k, b in self._texture_btns:
+            if k != key:
+                b.handler_block_by_func(self._on_texture_toggled)
+                b.set_active(False)
+                b.handler_unblock_by_func(self._on_texture_toggled)
+        self._theme.texture = key
+        self._emit()
+
+    def _on_reset(self, _btn):
+        import dataclasses
+        self._theme = Theme()
+        self._reload_controls()
+        self._emit()
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    def _update_accent_swatches(self):
+        for sw, (color, _) in zip(self._accent_swatches, ACCENT_PRESETS):
+            sw.set_active(color.lower() == self._theme.accent.lower())
+
+    def _update_bg_swatches(self):
+        for sw, (color, _) in zip(self._bg_swatches, BG_PRESETS):
+            sw.set_active(color.lower() == self._theme.bg_color.lower())
+
+    def _reload_controls(self):
+        if self._opacity_scale and self._opacity_handler:
+            self._opacity_scale.handler_block(self._opacity_handler)
+            self._opacity_scale.set_value(self._theme.window_opacity)
+            self._opacity_scale.handler_unblock(self._opacity_handler)
+
+        if self._card_scale and self._card_handler:
+            self._card_scale.handler_block(self._card_handler)
+            self._card_scale.set_value(self._theme.card_opacity)
+            self._card_scale.handler_unblock(self._card_handler)
+
+        if self._blur_scale and self._blur_handler:
+            self._blur_scale.handler_block(self._blur_handler)
+            self._blur_scale.set_value(self._theme.blur)
+            self._blur_scale.handler_unblock(self._blur_handler)
+
+        self._update_accent_swatches()
+        self._update_bg_swatches()
+
+        if self._accent_color_btn and self._accent_color_handler:
+            rgba = Gdk.RGBA()
+            rgba.parse(self._theme.accent)
+            self._accent_color_btn.handler_block(self._accent_color_handler)
+            self._accent_color_btn.set_rgba(rgba)
+            self._accent_color_btn.handler_unblock(self._accent_color_handler)
+
+        if self._bg_color_btn and self._bg_color_handler:
+            rgba = Gdk.RGBA()
+            rgba.parse(self._theme.bg_color)
+            self._bg_color_btn.handler_block(self._bg_color_handler)
+            self._bg_color_btn.set_rgba(rgba)
+            self._bg_color_btn.handler_unblock(self._bg_color_handler)
+
+        for key, btn in self._texture_btns:
+            btn.handler_block_by_func(self._on_texture_toggled)
+            btn.set_active(key == self._theme.texture)
+            btn.handler_unblock_by_func(self._on_texture_toggled)
+
+    def _emit(self):
+        import dataclasses
+        self._on_change_cb(dataclasses.replace(self._theme))

--- a/nothing_app/pages/theme.py
+++ b/nothing_app/pages/theme.py
@@ -6,7 +6,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gdk, GLib, Gtk
 
-from ..theme import ACCENT_PRESETS, BG_PRESETS, TEXTURES, Theme, hex_to_rgb
+from ..theme import ACCENT_PRESETS, BG_PRESETS, FONT_PRESETS, TEXTURES, Theme, hex_to_rgb
 
 
 # ── Swatch drawing area ───────────────────────────────────────────────────────
@@ -147,6 +147,7 @@ class ThemePage(Gtk.Box):
         self._blur_scale: Gtk.Scale | None = None
         self._blur_handler: int | None = None
         self._texture_btns: list[tuple[str, Gtk.ToggleButton]] = []
+        self._font_btns: list[tuple[str, Gtk.ToggleButton]] = []
         self._build()
 
     # ── Build ─────────────────────────────────────────────────────────────────
@@ -166,6 +167,7 @@ class ThemePage(Gtk.Box):
         self._build_glass(page)
         self._build_blur(page)
         self._build_texture(page)
+        self._build_font(page)
         self._build_reset(page)
 
     def _build_accent(self, page: Gtk.Box):
@@ -297,6 +299,32 @@ class ThemePage(Gtk.Box):
         group.append(btn_box)
         page.append(group)
 
+    def _build_font(self, page: Gtk.Box):
+        page.append(_section("FONT"))
+
+        group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        group.add_css_class("settings-group")
+        group.set_margin_bottom(4)
+
+        btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        btn_box.add_css_class("linked")
+        btn_box.set_margin_top(14)
+        btn_box.set_margin_bottom(14)
+        btn_box.set_margin_start(18)
+        btn_box.set_margin_end(18)
+        btn_box.set_hexpand(True)
+
+        for key, label in FONT_PRESETS:
+            btn = Gtk.ToggleButton(label=label)
+            btn.set_hexpand(True)
+            btn.set_active(key == self._theme.font_family)
+            btn.connect("toggled", self._on_font_toggled, key)
+            btn_box.append(btn)
+            self._font_btns.append((key, btn))
+
+        group.append(btn_box)
+        page.append(group)
+
     def _build_reset(self, page: Gtk.Box):
         reset = Gtk.Button(label="RESET TO DEFAULT")
         reset.add_css_class("disconnect-button")
@@ -379,6 +407,17 @@ class ThemePage(Gtk.Box):
         self._theme.texture = key
         self._emit()
 
+    def _on_font_toggled(self, btn: Gtk.ToggleButton, key: str):
+        if not btn.get_active():
+            return
+        for k, b in self._font_btns:
+            if k != key:
+                b.handler_block_by_func(self._on_font_toggled)
+                b.set_active(False)
+                b.handler_unblock_by_func(self._on_font_toggled)
+        self._theme.font_family = key
+        self._emit()
+
     def _on_reset(self, _btn):
         import dataclasses
         self._theme = Theme()
@@ -432,6 +471,11 @@ class ThemePage(Gtk.Box):
             btn.handler_block_by_func(self._on_texture_toggled)
             btn.set_active(key == self._theme.texture)
             btn.handler_unblock_by_func(self._on_texture_toggled)
+
+        for key, btn in self._font_btns:
+            btn.handler_block_by_func(self._on_font_toggled)
+            btn.set_active(key == self._theme.font_family)
+            btn.handler_unblock_by_func(self._on_font_toggled)
 
     def _emit(self):
         import dataclasses

--- a/nothing_app/profiles.py
+++ b/nothing_app/profiles.py
@@ -5,26 +5,114 @@ _DIR = os.path.expanduser("~/.config/something-x")
 _PROFILES_FILE = os.path.join(_DIR, "profiles.json")
 _LAST_DEV_FILE = os.path.join(_DIR, "last_device")
 
+_NOTIFY_DEFAULTS: dict = {"battery_low": True, "connect": True, "disconnect": True}
+_ALLOWED_IMPORT_KEYS = frozenset({"anc", "eq", "nickname", "notify"})
 
-def load(address: str) -> dict:
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+def _load_all() -> dict:
     try:
         with open(_PROFILES_FILE) as f:
-            return json.load(f).get(address, {})
+            return json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
 
 
-def save(address: str, anc_mode: int, eq_preset: str):
+def _save_all(data: dict):
     os.makedirs(_DIR, exist_ok=True)
-    data = {}
-    try:
-        with open(_PROFILES_FILE) as f:
-            data = json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError):
-        pass
-    data[address] = {"anc": anc_mode, "eq": eq_preset}
     with open(_PROFILES_FILE, "w") as f:
         json.dump(data, f, indent=2)
+
+
+# ── ANC / EQ profile ─────────────────────────────────────────────────────────
+
+
+def load(address: str) -> dict:
+    return _load_all().get(address, {})
+
+
+def save(address: str, anc_mode: int, eq_preset: str):
+    data = _load_all()
+    entry = data.setdefault(address, {})
+    entry["anc"] = anc_mode
+    entry["eq"] = eq_preset
+    _save_all(data)
+
+
+# ── Device nickname ───────────────────────────────────────────────────────────
+
+
+def get_nickname(address: str) -> str | None:
+    return _load_all().get(address, {}).get("nickname")
+
+
+def set_nickname(address: str, name: str | None):
+    data = _load_all()
+    entry = data.setdefault(address, {})
+    if name:
+        entry["nickname"] = name
+    else:
+        entry.pop("nickname", None)
+    _save_all(data)
+
+
+# ── Notification preferences ──────────────────────────────────────────────────
+
+
+def get_notify_prefs(address: str) -> dict:
+    """Return notification prefs for address, filling missing keys with defaults."""
+    stored = _load_all().get(address, {}).get("notify", {})
+    return {**_NOTIFY_DEFAULTS, **stored}
+
+
+def set_notify_prefs(address: str, prefs: dict):
+    data = _load_all()
+    entry = data.setdefault(address, {})
+    entry["notify"] = {**_NOTIFY_DEFAULTS, **entry.get("notify", {}), **prefs}
+    _save_all(data)
+
+
+# ── Import / export ───────────────────────────────────────────────────────────
+
+
+def export_profile(address: str) -> dict:
+    """Return the stored profile dict for a single device (empty dict if none)."""
+    return _load_all().get(address, {})
+
+
+def import_profile(address: str, data: dict):
+    """Merge known keys from data into the stored profile for address."""
+    all_data = _load_all()
+    entry = all_data.setdefault(address, {})
+    for key in _ALLOWED_IMPORT_KEYS:
+        if key in data:
+            entry[key] = data[key]
+    _save_all(all_data)
+
+
+def export_all() -> dict:
+    """Return the entire profiles store as a plain dict."""
+    return _load_all()
+
+
+def import_all(data: dict):
+    """Merge known keys from every address entry in data into the profiles store."""
+    if not isinstance(data, dict):
+        raise ValueError("Profile data must be a JSON object")
+    all_data = _load_all()
+    for address, entry in data.items():
+        if not isinstance(entry, dict):
+            continue
+        existing = all_data.setdefault(address, {})
+        for key in _ALLOWED_IMPORT_KEYS:
+            if key in entry:
+                existing[key] = entry[key]
+    _save_all(all_data)
+
+
+# ── Last device ───────────────────────────────────────────────────────────────
 
 
 def get_last_device() -> str | None:

--- a/nothing_app/protocol.py
+++ b/nothing_app/protocol.py
@@ -660,22 +660,25 @@ class NothingDevice(GObject.Object):
             if pct <= threshold and threshold not in notified:
                 notified.add(threshold)
                 if not first_reading:
-                    threading.Thread(
-                        target=subprocess.run,
-                        args=(
-                            [
-                                "notify-send",
-                                "-u",
-                                "critical",
-                                "-i",
-                                "battery-caution",
-                                "Something X",
-                                f"{label}: {pct}% battery remaining",
-                            ],
-                        ),
-                        kwargs={"capture_output": True},
-                        daemon=True,
-                    ).start()
+                    from . import profiles
+
+                    if profiles.get_notify_prefs(self.address).get("battery_low", True):
+                        threading.Thread(
+                            target=subprocess.run,
+                            args=(
+                                [
+                                    "notify-send",
+                                    "-u",
+                                    "critical",
+                                    "-i",
+                                    "battery-caution",
+                                    "Something X",
+                                    f"{label}: {pct}% battery remaining",
+                                ],
+                            ),
+                            kwargs={"capture_output": True},
+                            daemon=True,
+                        ).start()
                 break
 
     def _poll_earphone_status(self):

--- a/nothing_app/theme.py
+++ b/nothing_app/theme.py
@@ -29,16 +29,16 @@ BG_PRESETS: list[tuple[str, str]] = [
 ]
 
 TEXTURES: list[tuple[str, str]] = [
-    ("none",      "None"),
-    ("dots",      "Dots"),
+    ("none", "None"),
+    ("dots", "Dots"),
     ("scanlines", "Lines"),
-    ("noise",     "Noise"),
+    ("noise", "Noise"),
 ]
 
 FONT_PRESETS: list[tuple[str, str]] = [
-    ("",                        "System"),
-    ("Adwaita Sans",            "Adwaita"),
-    ("iA Writer Quattro S",     "iA Writer"),
+    ("", "System"),
+    ("Adwaita Sans", "Adwaita"),
+    ("iA Writer Quattro S", "iA Writer"),
     ("JetBrainsMono Nerd Font", "Mono"),
 ]
 
@@ -75,6 +75,7 @@ def save(t: Theme) -> None:
 
 # ── Color helpers ─────────────────────────────────────────────────────────────
 
+
 def hex_to_rgb(h: str) -> tuple[int, int, int]:
     h = h.lstrip("#")
     return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
@@ -87,19 +88,20 @@ def _rgba(h: str, alpha: float) -> str:
 
 def _darken(h: str, factor: float) -> str:
     r, g, b = hex_to_rgb(h)
-    return f"#{min(255,int(r*factor)):02x}{min(255,int(g*factor)):02x}{min(255,int(b*factor)):02x}"
+    return f"#{min(255, int(r * factor)):02x}{min(255, int(g * factor)):02x}{min(255, int(b * factor)):02x}"
 
 
 def _lighten(h: str, factor: float) -> str:
     r, g, b = hex_to_rgb(h)
     return (
-        f"#{min(255,int(r+(255-r)*factor)):02x}"
-        f"{min(255,int(g+(255-g)*factor)):02x}"
-        f"{min(255,int(b+(255-b)*factor)):02x}"
+        f"#{min(255, int(r + (255 - r) * factor)):02x}"
+        f"{min(255, int(g + (255 - g) * factor)):02x}"
+        f"{min(255, int(b + (255 - b) * factor)):02x}"
     )
 
 
 # ── Texture patterns ──────────────────────────────────────────────────────────
+
 
 def _texture_css(name: str) -> str:
     if name == "dots":
@@ -121,26 +123,24 @@ def _texture_css(name: str) -> str:
             '<filter id="n">'
             '<feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/>'
             '<feColorMatrix type="saturate" values="0"/>'
-            '</filter>'
+            "</filter>"
             '<rect width="128" height="128" filter="url(#n)" opacity="0.07"/>'
-            '</svg>'
+            "</svg>"
         )
         enc = base64.b64encode(svg.encode()).decode()
-        return (
-            f'background-image: url("data:image/svg+xml;base64,{enc}");'
-            ' background-size: 128px 128px;'
-        )
+        return f'background-image: url("data:image/svg+xml;base64,{enc}"); background-size: 128px 128px;'
     return "background-image: none;"
 
 
 # ── CSS generation ────────────────────────────────────────────────────────────
 
+
 def generate_css(t: Theme) -> str:
     acc = t.accent
-    dark    = _darken(acc, 0.72)
-    darker  = _darken(acc, 0.62)
+    dark = _darken(acc, 0.72)
+    darker = _darken(acc, 0.62)
     darkest = _darken(acc, 0.52)
-    hover   = _lighten(acc, 0.07)
+    hover = _lighten(acc, 0.07)
 
     def a(alpha: float) -> str:
         return _rgba(acc, alpha)
@@ -149,12 +149,16 @@ def generate_css(t: Theme) -> str:
     bg = t.bg_color
     # subtle gradient variants derived from bg_color
     bg_light = _lighten(bg, 0.05)
-    bg_dark  = _darken(bg, 0.80) if bg != "#000000" else bg
+    bg_dark = _darken(bg, 0.80) if bg != "#000000" else bg
 
-    c1  = co * 0.055;  c2  = co * 0.022
-    h1  = co * 0.082;  h2  = co * 0.036
-    s1  = co * 0.048;  s2  = co * 0.018
-    a1  = co * 0.040;  a2  = co * 0.014
+    c1 = co * 0.055
+    c2 = co * 0.022
+    h1 = co * 0.082
+    h2 = co * 0.036
+    s1 = co * 0.048
+    s2 = co * 0.018
+    a1 = co * 0.040
+    a2 = co * 0.014
 
     # blur and texture live on .app-background (behind content) — not on content widgets
     blur_rule = f"filter: blur({t.blur}px);" if t.blur else ""

--- a/nothing_app/theme.py
+++ b/nothing_app/theme.py
@@ -35,6 +35,13 @@ TEXTURES: list[tuple[str, str]] = [
     ("noise",     "Noise"),
 ]
 
+FONT_PRESETS: list[tuple[str, str]] = [
+    ("",                        "System"),
+    ("Adwaita Sans",            "Adwaita"),
+    ("iA Writer Quattro S",     "iA Writer"),
+    ("JetBrainsMono Nerd Font", "Mono"),
+]
+
 
 @dataclass
 class Theme:
@@ -44,6 +51,7 @@ class Theme:
     card_opacity: float = 1.0
     blur: int = 0
     texture: str = "none"
+    font_family: str = ""
 
 
 def load() -> Theme:
@@ -152,8 +160,11 @@ def generate_css(t: Theme) -> str:
     blur_rule = f"filter: blur({t.blur}px);" if t.blur else ""
     texture = _texture_css(t.texture)
 
+    font_rule = f'* {{ font-family: "{t.font_family}"; }}' if t.font_family else ""
+
     return f"""/* Nothing X — generated theme override */
 
+{font_rule}
 @define-color accent_color {acc};
 @define-color accent_bg_color {acc};
 @define-color accent_fg_color #ffffff;

--- a/nothing_app/theme.py
+++ b/nothing_app/theme.py
@@ -1,0 +1,297 @@
+import base64
+import json
+import os
+from dataclasses import asdict, dataclass
+
+_DIR = os.path.expanduser("~/.config/something-x")
+_THEME_FILE = os.path.join(_DIR, "theme.json")
+
+ACCENT_PRESETS: list[tuple[str, str]] = [
+    ("#e83535", "Red"),
+    ("#3b82f6", "Blue"),
+    ("#10b981", "Emerald"),
+    ("#f59e0b", "Amber"),
+    ("#8b5cf6", "Violet"),
+    ("#ec4899", "Pink"),
+    ("#06b6d4", "Cyan"),
+    ("#f97316", "Orange"),
+]
+
+BG_PRESETS: list[tuple[str, str]] = [
+    ("#000000", "Black"),
+    ("#0d1117", "Abyss"),
+    ("#1a1b26", "Night"),
+    ("#0f0e17", "Ink"),
+    ("#1e1e2e", "Mocha"),
+    ("#0a0f1e", "Ocean"),
+    ("#120028", "Void"),
+    ("#0a1a0a", "Forest"),
+]
+
+TEXTURES: list[tuple[str, str]] = [
+    ("none",      "None"),
+    ("dots",      "Dots"),
+    ("scanlines", "Lines"),
+    ("noise",     "Noise"),
+]
+
+
+@dataclass
+class Theme:
+    accent: str = "#e83535"
+    bg_color: str = "#000000"
+    window_opacity: float = 1.0
+    card_opacity: float = 1.0
+    blur: int = 0
+    texture: str = "none"
+
+
+def load() -> Theme:
+    try:
+        with open(_THEME_FILE) as f:
+            data = json.load(f)
+        # migrate old card_blur key
+        if "card_blur" in data and "blur" not in data:
+            data["blur"] = data.pop("card_blur")
+        valid = {k: v for k, v in data.items() if k in Theme.__dataclass_fields__}
+        return Theme(**valid)
+    except (FileNotFoundError, json.JSONDecodeError, TypeError):
+        return Theme()
+
+
+def save(t: Theme) -> None:
+    os.makedirs(_DIR, exist_ok=True)
+    with open(_THEME_FILE, "w") as f:
+        json.dump(asdict(t), f, indent=2)
+
+
+# ── Color helpers ─────────────────────────────────────────────────────────────
+
+def hex_to_rgb(h: str) -> tuple[int, int, int]:
+    h = h.lstrip("#")
+    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+
+
+def _rgba(h: str, alpha: float) -> str:
+    r, g, b = hex_to_rgb(h)
+    return f"rgba({r}, {g}, {b}, {alpha:.3f})"
+
+
+def _darken(h: str, factor: float) -> str:
+    r, g, b = hex_to_rgb(h)
+    return f"#{min(255,int(r*factor)):02x}{min(255,int(g*factor)):02x}{min(255,int(b*factor)):02x}"
+
+
+def _lighten(h: str, factor: float) -> str:
+    r, g, b = hex_to_rgb(h)
+    return (
+        f"#{min(255,int(r+(255-r)*factor)):02x}"
+        f"{min(255,int(g+(255-g)*factor)):02x}"
+        f"{min(255,int(b+(255-b)*factor)):02x}"
+    )
+
+
+# ── Texture patterns ──────────────────────────────────────────────────────────
+
+def _texture_css(name: str) -> str:
+    if name == "dots":
+        return (
+            "background-image:"
+            " radial-gradient(circle, rgba(255,255,255,0.06) 1px, transparent 1px);"
+            " background-size: 20px 20px;"
+        )
+    if name == "scanlines":
+        return (
+            "background-image:"
+            " repeating-linear-gradient("
+            "to bottom, rgba(255,255,255,0.028) 0px, rgba(255,255,255,0.028) 1px,"
+            " transparent 1px, transparent 4px);"
+        )
+    if name == "noise":
+        svg = (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128">'
+            '<filter id="n">'
+            '<feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/>'
+            '<feColorMatrix type="saturate" values="0"/>'
+            '</filter>'
+            '<rect width="128" height="128" filter="url(#n)" opacity="0.07"/>'
+            '</svg>'
+        )
+        enc = base64.b64encode(svg.encode()).decode()
+        return (
+            f'background-image: url("data:image/svg+xml;base64,{enc}");'
+            ' background-size: 128px 128px;'
+        )
+    return "background-image: none;"
+
+
+# ── CSS generation ────────────────────────────────────────────────────────────
+
+def generate_css(t: Theme) -> str:
+    acc = t.accent
+    dark    = _darken(acc, 0.72)
+    darker  = _darken(acc, 0.62)
+    darkest = _darken(acc, 0.52)
+    hover   = _lighten(acc, 0.07)
+
+    def a(alpha: float) -> str:
+        return _rgba(acc, alpha)
+
+    co = max(0.15, min(1.0, t.card_opacity))
+    bg = t.bg_color
+    # subtle gradient variants derived from bg_color
+    bg_light = _lighten(bg, 0.05)
+    bg_dark  = _darken(bg, 0.80) if bg != "#000000" else bg
+
+    c1  = co * 0.055;  c2  = co * 0.022
+    h1  = co * 0.082;  h2  = co * 0.036
+    s1  = co * 0.048;  s2  = co * 0.018
+    a1  = co * 0.040;  a2  = co * 0.014
+
+    # blur and texture live on .app-background (behind content) — not on content widgets
+    blur_rule = f"filter: blur({t.blur}px);" if t.blur else ""
+    texture = _texture_css(t.texture)
+
+    return f"""/* Nothing X — generated theme override */
+
+@define-color accent_color {acc};
+@define-color accent_bg_color {acc};
+@define-color accent_fg_color #ffffff;
+
+@keyframes dot-pulse {{
+    0%, 100% {{ box-shadow: 0 0 6px {a(0.62)}; }}
+    50%       {{ box-shadow: 0 0 14px {a(0.92)}, 0 0 28px {a(0.20)}; }}
+}}
+@keyframes scan-bloom {{
+    0%, 100% {{
+        box-shadow:
+            0 0 0 1px {a(0.12)},
+            0 4px 24px {a(0.38)},
+            0 12px 48px {a(0.15)},
+            inset 0 1px 0 rgba(255,148,148,0.24),
+            inset 0 -1px 0 rgba(0,0,0,0.38);
+    }}
+    50% {{
+        box-shadow:
+            0 0 0 1px {a(0.22)},
+            0 4px 34px {a(0.54)},
+            0 12px 68px {a(0.24)},
+            inset 0 1px 0 rgba(255,148,148,0.30),
+            inset 0 -1px 0 rgba(0,0,0,0.38);
+    }}
+}}
+
+window, .background {{ background-color: {bg}; }}
+
+/* Background layer — gradient, texture, blur all here.
+   Content (nav view) sits above as a sibling, so blur doesn't touch it. */
+.app-background {{
+    background: linear-gradient(180deg, {bg_light} 0%, {bg_dark} 18%);
+    {blur_rule}
+    {texture}
+}}
+
+/* Make the navigation stack and scroll containers transparent
+   so the background layer shows through cleanly. */
+adw-navigation-view, adw-toolbar-view {{ background-color: transparent; }}
+scrolledwindow, viewport {{ background-color: transparent; }}
+.nothing-page {{ background: transparent; }}
+
+.device-card {{
+    background: linear-gradient(155deg, rgba(255,255,255,{c1:.4f}) 0%, rgba(255,255,255,{c2:.4f}) 100%);
+}}
+.device-card:hover {{
+    background: linear-gradient(155deg, rgba(255,255,255,{h1:.4f}) 0%, rgba(255,255,255,{h2:.4f}) 100%);
+}}
+.settings-group {{
+    background: linear-gradient(180deg, rgba(255,255,255,{s1:.4f}) 0%, rgba(255,255,255,{s2:.4f}) 100%);
+}}
+.anc-container {{
+    background: linear-gradient(180deg, rgba(255,255,255,{a1:.4f}) 0%, rgba(255,255,255,{a2:.4f}) 100%);
+}}
+
+.anc-button.active, .anc-button:checked {{
+    background: linear-gradient(160deg, {acc} 0%, {dark} 100%);
+    box-shadow: 0 2px 16px {a(0.38)}, inset 0 1px 0 rgba(255,255,255,0.20);
+}}
+.anc-button.active:hover, .anc-button:checked:hover {{
+    background: linear-gradient(160deg, {hover} 0%, {darker} 100%);
+}}
+.eq-button.active, .eq-button:checked {{
+    background: linear-gradient(160deg, {acc} 0%, {dark} 100%);
+    border-color: transparent;
+    box-shadow: 0 2px 16px {a(0.36)}, inset 0 1px 0 rgba(255,255,255,0.20);
+}}
+.eq-button.active:hover, .eq-button:checked:hover {{
+    background: linear-gradient(160deg, {hover} 0%, {darker} 100%);
+}}
+
+scale trough highlight {{
+    background: linear-gradient(90deg, {darkest} 0%, {acc} 65%, {hover} 100%);
+    box-shadow: 0 0 10px {a(0.36)};
+}}
+scale slider:active {{
+    box-shadow:
+        0 0 0 5px {a(0.15)},
+        0 0 0 10px {a(0.06)},
+        0 2px 12px rgba(0,0,0,0.65),
+        inset 0 1px 0 rgba(255,255,255,0.50);
+}}
+
+switch:checked {{
+    background: linear-gradient(160deg, {acc} 0%, {dark} 100%);
+    border-color: {a(0.18)};
+    box-shadow: 0 0 14px {a(0.32)}, 0 0 36px {a(0.10)}, inset 0 2px 6px rgba(0,0,0,0.20);
+}}
+
+.scan-button {{
+    background: linear-gradient(160deg, {acc} 0%, {dark} 100%);
+    border-color: {a(0.18)};
+    box-shadow:
+        0 0 0 1px {a(0.12)},
+        0 4px 24px {a(0.38)},
+        0 12px 48px {a(0.15)},
+        inset 0 1px 0 rgba(255,148,148,0.24),
+        inset 0 -1px 0 rgba(0,0,0,0.38);
+}}
+.scan-button:hover {{
+    background: linear-gradient(160deg, {hover} 0%, {darker} 100%);
+    box-shadow:
+        0 0 0 1px {a(0.20)},
+        0 6px 32px {a(0.52)},
+        0 16px 60px {a(0.22)},
+        inset 0 1px 0 rgba(255,148,148,0.30),
+        inset 0 -1px 0 rgba(0,0,0,0.38);
+}}
+.scan-button:active {{
+    background: linear-gradient(160deg, {dark} 0%, {darkest} 100%);
+    box-shadow:
+        0 0 0 1px {a(0.08)},
+        0 2px 12px {a(0.28)},
+        inset 0 1px 0 rgba(255,148,148,0.16),
+        inset 0 -1px 0 rgba(0,0,0,0.42);
+}}
+
+.disconnect-button {{
+    background: {a(0.07)};
+    border-color: {a(0.18)};
+}}
+.disconnect-button label {{ color: {a(0.75)}; }}
+.disconnect-button:hover {{
+    background: {a(0.12)};
+    border-color: {a(0.30)};
+    box-shadow: 0 0 16px {a(0.11)}, inset 0 1px 0 rgba(255,255,255,0.04);
+}}
+.disconnect-button:hover label {{ color: {acc}; }}
+
+.nothing-dot {{
+    background-color: {acc};
+    box-shadow: 0 0 6px {a(0.62)};
+}}
+.status-nothing {{
+    color: {acc};
+    background: {a(0.10)};
+    border-color: {a(0.22)};
+}}
+progressbar progress {{ background-color: {acc}; }}
+"""

--- a/nothing_app/window.py
+++ b/nothing_app/window.py
@@ -65,8 +65,20 @@ class SomethingXWindow(Adw.ApplicationWindow):
                 _send_notify("Something X", f"{name} disconnected")
 
     def _build(self):
+        overlay = Gtk.Overlay()
+
+        # Background layer — CSS blur applies here only, not to content
+        bg = Gtk.Box()
+        bg.set_vexpand(True)
+        bg.set_hexpand(True)
+        bg.add_css_class("app-background")
+        overlay.set_child(bg)
+
         nav = Adw.NavigationView()
-        self.set_content(nav)
+        overlay.add_overlay(nav)
+        overlay.set_measure_overlay(nav, True)
+        overlay.set_clip_overlay(nav, True)
+        self.set_content(overlay)
         self._nav = nav
         nav.push(self._make_home_nav_page())
 
@@ -93,6 +105,11 @@ class SomethingXWindow(Adw.ApplicationWindow):
         close_btn.set_tooltip_text("Hide window, keep running in background")
         close_btn.connect("clicked", lambda _: self.hide())
         header.pack_start(close_btn)
+
+        theme_btn = Gtk.Button.new_from_icon_name("preferences-color-symbolic")
+        theme_btn.set_tooltip_text("Appearance")
+        theme_btn.connect("clicked", self._open_theme_page)
+        header.pack_end(theme_btn)
 
         bt_btn = Gtk.Button.new_from_icon_name("bluetooth-symbolic")
         bt_btn.set_tooltip_text("Bluetooth settings")
@@ -130,6 +147,32 @@ class SomethingXWindow(Adw.ApplicationWindow):
 
         nav_page.set_child(toolbar_view)
         nav_page.connect("hidden", lambda _: device_page.cleanup())
+        return nav_page
+
+    def _open_theme_page(self, _btn):
+        if self._nav.find_page("theme"):
+            return
+        self._nav.push(self._make_theme_nav_page())
+
+    def _make_theme_nav_page(self) -> Adw.NavigationPage:
+        nav_page = Adw.NavigationPage()
+        nav_page.set_tag("theme")
+        nav_page.set_title("Appearance")
+
+        toolbar_view = Adw.ToolbarView()
+        header = Adw.HeaderBar()
+        header.add_css_class("nothing-header")
+        toolbar_view.add_top_bar(header)
+
+        app = self.get_application()
+        from .pages.theme import ThemePage
+
+        theme_page = ThemePage(
+            theme=app._current_theme,
+            on_change=app.apply_theme,
+        )
+        toolbar_view.set_content(theme_page)
+        nav_page.set_child(toolbar_view)
         return nav_page
 
     def _on_device_selected(self, _home, bt_device: BluetoothDevice):

--- a/nothing_app/window.py
+++ b/nothing_app/window.py
@@ -1,14 +1,25 @@
+import subprocess
+import threading
 import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw
 
-from . import __version__
+from . import __version__, profiles
 from .bluetooth import BluetoothDevice, BluetoothManager
 from .protocol import NothingDevice
 from .pages.home import HomePage
 from .pages.device import DevicePage
+
+
+def _send_notify(summary: str, body: str, icon: str = "audio-headphones"):
+    threading.Thread(
+        target=subprocess.run,
+        args=(["notify-send", "-i", icon, summary, body],),
+        kwargs={"capture_output": True},
+        daemon=True,
+    ).start()
 
 
 class SomethingXWindow(Adw.ApplicationWindow):
@@ -39,11 +50,19 @@ class SomethingXWindow(Adw.ApplicationWindow):
         dev = self._bt.devices.get(path)
         if dev and dev.is_nothing:
             self._start_nothing_device(path, dev.address)
+            if profiles.get_notify_prefs(dev.address).get("connect", True):
+                name = profiles.get_nickname(dev.address) or dev.name
+                _send_notify("Something X", f"{name} connected")
 
     def _on_bt_disconnected(self, _mgr, path: str):
+        dev = self._bt.devices.get(path)
         nd = self._nothing_devices.pop(path, None)
         if nd:
             nd.disconnect_rfcomm()
+        if dev and dev.is_nothing:
+            if profiles.get_notify_prefs(dev.address).get("disconnect", True):
+                name = profiles.get_nickname(dev.address) or dev.name
+                _send_notify("Something X", f"{name} disconnected")
 
     def _build(self):
         nav = Adw.NavigationView()
@@ -64,6 +83,16 @@ class SomethingXWindow(Adw.ApplicationWindow):
         title_widget.set_title("Something X")
         title_widget.set_subtitle(__version__)
         header.set_title_widget(title_widget)
+
+        quit_btn = Gtk.Button(label="Quit")
+        quit_btn.set_tooltip_text("Quit the app and stop background process")
+        quit_btn.connect("clicked", lambda _: self.get_application().quit())
+        header.pack_start(quit_btn)
+
+        close_btn = Gtk.Button(label="Close")
+        close_btn.set_tooltip_text("Hide window, keep running in background")
+        close_btn.connect("clicked", lambda _: self.hide())
+        header.pack_start(close_btn)
 
         bt_btn = Gtk.Button.new_from_icon_name("bluetooth-symbolic")
         bt_btn.set_tooltip_text("Bluetooth settings")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ def mock_profiles(monkeypatch):
     monkeypatch.setattr(profiles, "save", MagicMock())
     monkeypatch.setattr(profiles, "load", MagicMock(return_value={}))
     monkeypatch.setattr(profiles, "set_last_device", MagicMock())
+    monkeypatch.setattr(profiles, "get_notify_prefs", MagicMock(return_value={"battery_low": True, "connect": True, "disconnect": True}))
+    monkeypatch.setattr(profiles, "get_nickname", MagicMock(return_value=None))
 
 
 def build_device_frame(cmd_id: int, payload: bytes = b"", fsn: int = 1) -> bytes:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,133 @@
+"""Tests for notification gating — battery low, connect, disconnect."""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nothing_app import profiles
+from nothing_app.protocol import NothingDevice
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(profiles, "_DIR", str(tmp_path))
+    monkeypatch.setattr(profiles, "_PROFILES_FILE", str(tmp_path / "profiles.json"))
+    monkeypatch.setattr(profiles, "_LAST_DEV_FILE", str(tmp_path / "last_device"))
+
+
+_ADDR = "AA:BB:CC:DD:EE:FF"
+
+
+def _make_device() -> NothingDevice:
+    return NothingDevice(_ADDR)
+
+
+def _fire_low_battery(dev: NothingDevice, pct: int = 10):
+    """Simulate a low-battery reading that is NOT the first observation."""
+    dev._low_bat_seen.add("left")
+    dev._check_low_battery("left", pct, "Left earbud")
+
+
+# ── battery_low pref ──────────────────────────────────────────────────────────
+
+
+def test_battery_low_notification_sent_when_enabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(profiles, "_PROFILES_FILE", str(tmp_path / "profiles.json"))
+    profiles.set_notify_prefs(_ADDR, {"battery_low": True})
+
+    fired = threading.Event()
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        fired.set()
+
+    dev = _make_device()
+    with patch("nothing_app.protocol.subprocess.run", fake_run):
+        _fire_low_battery(dev)
+        fired.wait(timeout=2)
+
+    assert any("notify-send" in c for c in calls), "notify-send should have been called"
+
+
+def test_battery_low_notification_suppressed_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(profiles, "_PROFILES_FILE", str(tmp_path / "profiles.json"))
+    profiles.set_notify_prefs(_ADDR, {"battery_low": False})
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+
+    dev = _make_device()
+    with patch("nothing_app.protocol.subprocess.run", fake_run):
+        _fire_low_battery(dev)
+        # Give the thread a moment in case it was incorrectly spawned
+        import time
+
+        time.sleep(0.1)
+
+    assert not calls, "notify-send should NOT have been called"
+
+
+def test_battery_low_not_sent_on_first_reading():
+    """First battery reading after connect should never trigger a notification."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+
+    dev = _make_device()
+    with patch("nothing_app.protocol.subprocess.run", fake_run):
+        # Do NOT pre-seed _low_bat_seen — this is the first reading
+        dev._check_low_battery("left", 5, "Left earbud")
+        import time
+
+        time.sleep(0.1)
+
+    assert not calls
+
+
+def test_battery_low_deduplicates_threshold():
+    """Each threshold fires at most once per connection even with repeated low readings."""
+    fired_count = [0]
+    lock = threading.Lock()
+
+    def fake_run(cmd, **kwargs):
+        with lock:
+            fired_count[0] += 1
+
+    dev = _make_device()
+    dev._low_bat_seen.add("left")
+    # Pre-mark all thresholds as already notified so repeat calls cannot fire.
+    dev._low_bat_notified["left"] = set(dev._LOW_BAT_THRESHOLDS)
+
+    with patch("nothing_app.protocol.subprocess.run", fake_run):
+        dev._check_low_battery("left", 5, "Left earbud")
+        dev._check_low_battery("left", 5, "Left earbud")
+        import time
+
+        time.sleep(0.1)
+
+    assert fired_count[0] == 0, "all thresholds already notified — should not fire again"
+
+
+# ── notify_prefs defaults ─────────────────────────────────────────────────────
+
+
+def test_battery_low_sent_with_default_prefs():
+    """With no stored prefs, battery_low defaults to True → notification fires."""
+    fired = threading.Event()
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        fired.set()
+
+    dev = _make_device()
+    with patch("nothing_app.protocol.subprocess.run", fake_run):
+        _fire_low_battery(dev)
+        fired.wait(timeout=2)
+
+    assert calls

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -88,3 +88,180 @@ def test_set_last_device_overwrites():
     profiles.set_last_device("11:22:33:44:55:66")
     profiles.set_last_device("AA:BB:CC:DD:EE:FF")
     assert profiles.get_last_device() == "AA:BB:CC:DD:EE:FF"
+
+
+# ── save preserves other fields ───────────────────────────────────────────────
+
+
+def test_save_preserves_nickname():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.set_nickname(addr, "My Ears")
+    profiles.save(addr, ANCMode.OFF, "Balanced")
+    assert profiles.get_nickname(addr) == "My Ears"
+
+
+def test_save_preserves_notify_prefs():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.set_notify_prefs(addr, {"battery_low": False})
+    profiles.save(addr, ANCMode.OFF, "Balanced")
+    assert profiles.get_notify_prefs(addr)["battery_low"] is False
+
+
+# ── nickname ──────────────────────────────────────────────────────────────────
+
+
+def test_get_nickname_none_when_not_set():
+    assert profiles.get_nickname("AA:BB:CC:DD:EE:FF") is None
+
+
+def test_set_and_get_nickname():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.set_nickname(addr, "Studio Buds")
+    assert profiles.get_nickname(addr) == "Studio Buds"
+
+
+def test_nickname_cleared_by_none():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.set_nickname(addr, "Studio Buds")
+    profiles.set_nickname(addr, None)
+    assert profiles.get_nickname(addr) is None
+
+
+def test_nickname_cleared_by_empty_string():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.set_nickname(addr, "Studio Buds")
+    profiles.set_nickname(addr, "")
+    assert profiles.get_nickname(addr) is None
+
+
+def test_nickname_does_not_affect_other_device():
+    profiles.set_nickname("AA:BB:CC:DD:EE:FF", "Mine")
+    assert profiles.get_nickname("11:22:33:44:55:66") is None
+
+
+# ── notify_prefs ──────────────────────────────────────────────────────────────
+
+
+def test_get_notify_prefs_defaults_all_true():
+    prefs = profiles.get_notify_prefs("AA:BB:CC:DD:EE:FF")
+    assert prefs == {"battery_low": True, "connect": True, "disconnect": True}
+
+
+def test_set_notify_prefs_roundtrip():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.set_notify_prefs(addr, {"battery_low": False, "connect": False, "disconnect": False})
+    prefs = profiles.get_notify_prefs(addr)
+    assert prefs["battery_low"] is False
+    assert prefs["connect"] is False
+    assert prefs["disconnect"] is False
+
+
+def test_set_notify_prefs_partial_does_not_clobber_others():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.set_notify_prefs(addr, {"battery_low": False})
+    prefs = profiles.get_notify_prefs(addr)
+    assert prefs["battery_low"] is False
+    assert prefs["connect"] is True
+    assert prefs["disconnect"] is True
+
+
+def test_notify_prefs_independent_per_device():
+    profiles.set_notify_prefs("AA:BB:CC:DD:EE:FF", {"battery_low": False})
+    prefs_other = profiles.get_notify_prefs("11:22:33:44:55:66")
+    assert prefs_other["battery_low"] is True
+
+
+# ── export / import single profile ────────────────────────────────────────────
+
+
+def test_export_profile_returns_stored_data():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.save(addr, ANCMode.NOISE_CANCELLATION, "More Bass")
+    profiles.set_nickname(addr, "Workout")
+    data = profiles.export_profile(addr)
+    assert data["anc"] == ANCMode.NOISE_CANCELLATION
+    assert data["eq"] == "More Bass"
+    assert data["nickname"] == "Workout"
+
+
+def test_export_profile_missing_returns_empty():
+    assert profiles.export_profile("AA:BB:CC:DD:EE:FF") == {}
+
+
+def test_import_profile_merges_known_keys():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.save(addr, ANCMode.OFF, "Balanced")
+    profiles.import_profile(addr, {"eq": "More Treble", "nickname": "Imported"})
+    p = profiles.load(addr)
+    assert p["anc"] == ANCMode.OFF
+    assert p["eq"] == "More Treble"
+    assert profiles.get_nickname(addr) == "Imported"
+
+
+def test_import_profile_ignores_unknown_keys():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.import_profile(addr, {"eq": "Voice", "malicious": "data"})
+    raw = profiles.export_profile(addr)
+    assert "malicious" not in raw
+
+
+def test_import_export_roundtrip():
+    addr = "AA:BB:CC:DD:EE:FF"
+    profiles.save(addr, ANCMode.TRANSPARENCY, "Voice")
+    profiles.set_nickname(addr, "Travel")
+    profiles.set_notify_prefs(addr, {"battery_low": False})
+    exported = profiles.export_profile(addr)
+
+    # Wipe and re-import
+    profiles.import_profile("BB:CC:DD:EE:FF:00", exported)
+    p2 = profiles.load("BB:CC:DD:EE:FF:00")
+    assert p2["anc"] == ANCMode.TRANSPARENCY
+    assert p2["eq"] == "Voice"
+    assert profiles.get_nickname("BB:CC:DD:EE:FF:00") == "Travel"
+
+
+# ── export / import all profiles ──────────────────────────────────────────────
+
+
+def test_export_all_returns_full_dict():
+    profiles.save("AA:BB:CC:DD:EE:FF", ANCMode.OFF, "Balanced")
+    profiles.save("11:22:33:44:55:66", ANCMode.TRANSPARENCY, "Voice")
+    all_data = profiles.export_all()
+    assert "AA:BB:CC:DD:EE:FF" in all_data
+    assert "11:22:33:44:55:66" in all_data
+
+
+def test_import_all_merges_multiple_devices():
+    incoming = {
+        "AA:BB:CC:DD:EE:FF": {"anc": ANCMode.NOISE_CANCELLATION, "eq": "More Bass"},
+        "11:22:33:44:55:66": {"eq": "Voice", "nickname": "Partner"},
+    }
+    profiles.import_all(incoming)
+    assert profiles.load("AA:BB:CC:DD:EE:FF")["anc"] == ANCMode.NOISE_CANCELLATION
+    assert profiles.get_nickname("11:22:33:44:55:66") == "Partner"
+
+
+def test_import_all_raises_on_non_dict():
+    import pytest
+
+    with pytest.raises(ValueError):
+        profiles.import_all("not a dict")
+
+
+def test_import_all_skips_non_dict_entries():
+    profiles.import_all({"AA:BB:CC:DD:EE:FF": "bad_entry"})
+    assert profiles.load("AA:BB:CC:DD:EE:FF") == {}
+
+
+def test_export_all_import_all_roundtrip():
+    profiles.save("AA:BB:CC:DD:EE:FF", ANCMode.OFF, "Balanced")
+    profiles.set_nickname("AA:BB:CC:DD:EE:FF", "Home")
+    snapshot = profiles.export_all()
+
+    # Reset and restore
+    import json as _json
+
+    profiles._save_all({})
+    profiles.import_all(snapshot)
+    assert profiles.load("AA:BB:CC:DD:EE:FF")["eq"] == "Balanced"
+    assert profiles.get_nickname("AA:BB:CC:DD:EE:FF") == "Home"

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,454 @@
+"""Tests for the theme module — data, persistence, color helpers, CSS generation."""
+
+import json
+
+import pytest
+
+from nothing_app import theme as _tm
+from nothing_app.theme import (
+    Theme,
+    _darken,
+    _lighten,
+    _rgba,
+    _texture_css,
+    generate_css,
+    hex_to_rgb,
+    load,
+    save,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_theme(tmp_path, monkeypatch):
+    monkeypatch.setattr(_tm, "_DIR", str(tmp_path))
+    monkeypatch.setattr(_tm, "_THEME_FILE", str(tmp_path / "theme.json"))
+
+
+# ── Theme dataclass defaults ──────────────────────────────────────────────────
+
+
+def test_default_accent():
+    assert Theme().accent == "#e83535"
+
+
+def test_default_bg_color():
+    assert Theme().bg_color == "#000000"
+
+
+def test_default_window_opacity():
+    assert Theme().window_opacity == 1.0
+
+
+def test_default_card_opacity():
+    assert Theme().card_opacity == 1.0
+
+
+def test_default_blur():
+    assert Theme().blur == 0
+
+
+def test_default_texture():
+    assert Theme().texture == "none"
+
+
+# ── load / save round-trip ────────────────────────────────────────────────────
+
+
+def test_load_missing_file_returns_defaults():
+    t = load()
+    assert t == Theme()
+
+
+def test_load_bad_json_returns_defaults(tmp_path):
+    (tmp_path / "theme.json").write_text("not json")
+    t = load()
+    assert t == Theme()
+
+
+def test_save_and_load_roundtrip():
+    t = Theme(accent="#3b82f6", bg_color="#1a1b26", window_opacity=0.8, card_opacity=0.5, blur=6, texture="dots")
+    save(t)
+    t2 = load()
+    assert t2 == t
+
+
+def test_save_creates_directory(tmp_path, monkeypatch):
+    nested = tmp_path / "deep" / "config"
+    monkeypatch.setattr(_tm, "_DIR", str(nested))
+    monkeypatch.setattr(_tm, "_THEME_FILE", str(nested / "theme.json"))
+    save(Theme())
+    assert (nested / "theme.json").exists()
+
+
+def test_save_writes_valid_json(tmp_path):
+    save(Theme(accent="#ec4899", bg_color="#0f0e17"))
+    data = json.loads((tmp_path / "theme.json").read_text())
+    assert data["accent"] == "#ec4899"
+    assert data["bg_color"] == "#0f0e17"
+
+
+def test_load_ignores_unknown_keys(tmp_path):
+    (tmp_path / "theme.json").write_text('{"accent":"#ffffff","unknown_key":42}')
+    t = load()
+    assert t.accent == "#ffffff"
+    assert not hasattr(t, "unknown_key")
+
+
+def test_load_uses_defaults_for_missing_keys(tmp_path):
+    (tmp_path / "theme.json").write_text('{"accent":"#06b6d4"}')
+    t = load()
+    assert t.accent == "#06b6d4"
+    assert t.window_opacity == 1.0
+    assert t.blur == 0
+
+
+def test_load_migrates_card_blur_to_blur(tmp_path):
+    (tmp_path / "theme.json").write_text('{"accent":"#e83535","card_blur":8}')
+    t = load()
+    assert t.blur == 8
+
+
+# ── hex_to_rgb ────────────────────────────────────────────────────────────────
+
+
+def test_hex_to_rgb_red():
+    assert hex_to_rgb("#e83535") == (232, 53, 53)
+
+
+def test_hex_to_rgb_blue():
+    assert hex_to_rgb("#3b82f6") == (59, 130, 246)
+
+
+def test_hex_to_rgb_black():
+    assert hex_to_rgb("#000000") == (0, 0, 0)
+
+
+def test_hex_to_rgb_white():
+    assert hex_to_rgb("#ffffff") == (255, 255, 255)
+
+
+def test_hex_to_rgb_without_hash():
+    assert hex_to_rgb("10b981") == (16, 185, 129)
+
+
+# ── _rgba ─────────────────────────────────────────────────────────────────────
+
+
+def test_rgba_format():
+    result = _rgba("#e83535", 0.5)
+    assert result == "rgba(232, 53, 53, 0.500)"
+
+
+def test_rgba_full_opacity():
+    result = _rgba("#000000", 1.0)
+    assert result == "rgba(0, 0, 0, 1.000)"
+
+
+def test_rgba_zero_opacity():
+    result = _rgba("#ffffff", 0.0)
+    assert result == "rgba(255, 255, 255, 0.000)"
+
+
+# ── _darken ───────────────────────────────────────────────────────────────────
+
+
+def test_darken_reduces_each_channel():
+    r, g, b = hex_to_rgb(_darken("#e83535", 0.5))
+    assert r < 232 and g < 53 and b < 53
+
+
+def test_darken_full_factor_unchanged():
+    assert _darken("#e83535", 1.0) == "#e83535"
+
+
+def test_darken_zero_gives_black():
+    assert _darken("#e83535", 0.0) == "#000000"
+
+
+def test_darken_does_not_exceed_255():
+    result = _darken("#ffffff", 2.0)
+    r, g, b = hex_to_rgb(result)
+    assert r <= 255 and g <= 255 and b <= 255
+
+
+def test_darken_black_stays_black():
+    assert _darken("#000000", 0.5) == "#000000"
+
+
+# ── _lighten ──────────────────────────────────────────────────────────────────
+
+
+def test_lighten_increases_each_channel():
+    orig_r, orig_g, orig_b = hex_to_rgb("#3b82f6")
+    r, g, b = hex_to_rgb(_lighten("#3b82f6", 0.2))
+    assert r >= orig_r and g >= orig_g and b >= orig_b
+
+
+def test_lighten_zero_factor_unchanged():
+    assert _lighten("#e83535", 0.0) == "#e83535"
+
+
+def test_lighten_full_factor_gives_white():
+    assert _lighten("#e83535", 1.0) == "#ffffff"
+
+
+def test_lighten_does_not_exceed_255():
+    result = _lighten("#ffffff", 0.5)
+    r, g, b = hex_to_rgb(result)
+    assert r <= 255 and g <= 255 and b <= 255
+
+
+# ── _texture_css ──────────────────────────────────────────────────────────────
+
+
+def test_texture_none_clears_image():
+    css = _texture_css("none")
+    assert "none" in css
+    assert "background-image" in css
+
+
+def test_texture_dots_uses_radial_gradient():
+    css = _texture_css("dots")
+    assert "radial-gradient" in css
+    assert "background-size" in css
+
+
+def test_texture_scanlines_uses_repeating_gradient():
+    css = _texture_css("scanlines")
+    assert "repeating-linear-gradient" in css
+
+
+def test_texture_noise_uses_data_uri():
+    css = _texture_css("noise")
+    assert "data:image/svg+xml;base64," in css
+    assert "background-size" in css
+
+
+def test_texture_noise_base64_is_valid():
+    import base64 as _b64
+
+    css = _texture_css("noise")
+    b64_part = css.split("base64,")[1].split('"')[0].strip().rstrip(";").strip()
+    decoded = _b64.b64decode(b64_part)
+    assert b"<svg" in decoded
+
+
+# ── generate_css — structure ──────────────────────────────────────────────────
+
+
+def test_generate_css_contains_accent_define_color():
+    css = generate_css(Theme(accent="#3b82f6"))
+    assert "@define-color accent_color #3b82f6" in css
+    assert "@define-color accent_bg_color #3b82f6" in css
+
+
+def test_generate_css_contains_keyframes():
+    css = generate_css(Theme())
+    assert "@keyframes dot-pulse" in css
+    assert "@keyframes scan-bloom" in css
+
+
+def test_generate_css_contains_anc_button_active():
+    css = generate_css(Theme())
+    assert ".anc-button.active" in css
+
+
+def test_generate_css_contains_eq_button_active():
+    css = generate_css(Theme())
+    assert ".eq-button.active" in css
+
+
+def test_generate_css_contains_switch_checked():
+    css = generate_css(Theme())
+    assert "switch:checked" in css
+
+
+def test_generate_css_contains_scan_button():
+    css = generate_css(Theme())
+    assert ".scan-button" in css
+
+
+def test_generate_css_contains_nothing_dot():
+    css = generate_css(Theme())
+    assert ".nothing-dot" in css
+
+
+def test_generate_css_contains_progress_bar():
+    css = generate_css(Theme())
+    assert "progressbar progress" in css
+
+
+def test_generate_css_contains_disconnect_button():
+    css = generate_css(Theme())
+    assert ".disconnect-button" in css
+
+
+# ── generate_css — accent propagation ────────────────────────────────────────
+
+
+def test_generate_css_blue_accent_appears_in_output():
+    css = generate_css(Theme(accent="#3b82f6"))
+    assert "#3b82f6" in css
+
+
+def test_generate_css_custom_accent_rgba_in_keyframes():
+    css = generate_css(Theme(accent="#10b981"))
+    r, g, b = hex_to_rgb("#10b981")
+    assert f"rgba({r}, {g}, {b}," in css
+
+
+def test_generate_css_default_accent_matches_original_red():
+    css = generate_css(Theme())
+    assert "#e83535" in css
+
+
+# ── generate_css — background color ──────────────────────────────────────────
+
+
+def test_generate_css_bg_color_appears_in_window_rule():
+    css = generate_css(Theme(bg_color="#1a1b26"))
+    win_block = css.split("window, .background")[1].split("}")[0]
+    assert "#1a1b26" in win_block
+
+
+def test_generate_css_bg_color_default_is_black():
+    css = generate_css(Theme())
+    win_block = css.split("window, .background")[1].split("}")[0]
+    assert "#000000" in win_block
+
+
+def test_generate_css_custom_bg_used_in_app_background_gradient():
+    css = generate_css(Theme(bg_color="#1e1e2e"))
+    bg_block = css[css.index(".app-background {"):][:300]
+    assert "1e1e2e" in bg_block or "background" in bg_block
+
+
+def test_generate_css_different_bg_colors_produce_different_output():
+    css_a = generate_css(Theme(bg_color="#000000"))
+    css_b = generate_css(Theme(bg_color="#1a1b26"))
+    assert css_a != css_b
+
+
+# ── generate_css — blur on background ────────────────────────────────────────
+
+
+def test_generate_css_no_blur_omits_filter():
+    css = generate_css(Theme(blur=0))
+    assert "filter: blur(" not in css
+
+
+def test_generate_css_blur_emits_filter():
+    css = generate_css(Theme(blur=8))
+    assert "filter: blur(8px)" in css
+
+
+def test_generate_css_blur_appears_in_app_background():
+    css = generate_css(Theme(blur=4))
+    bg_section = css[css.index(".app-background {"):]
+    first_block = bg_section[:bg_section.index("}") + 1]
+    assert "blur(4px)" in first_block
+
+
+def test_generate_css_blur_not_in_nothing_page():
+    css = generate_css(Theme(blur=6))
+    page_section = css[css.index(".nothing-page {"):]
+    first_block = page_section[:page_section.index("}") + 1]
+    assert "blur(" not in first_block
+
+
+def test_generate_css_blur_not_in_device_card():
+    css = generate_css(Theme(blur=6))
+    card_section = css[css.index(".device-card {"):]
+    first_block = card_section[:card_section.index("}") + 1]
+    assert "blur(" not in first_block
+
+
+def test_generate_css_blur_not_in_settings_group():
+    css = generate_css(Theme(blur=6))
+    group_section = css[css.index(".settings-group {"):]
+    first_block = group_section[:group_section.index("}") + 1]
+    assert "blur(" not in first_block
+
+
+# ── generate_css — card opacity ───────────────────────────────────────────────
+
+
+def test_generate_css_card_opacity_scales_alpha():
+    css_full = generate_css(Theme(card_opacity=1.0))
+    css_half = generate_css(Theme(card_opacity=0.5))
+    assert ".device-card" in css_full
+    assert ".device-card" in css_half
+
+    def extract_device_card_block(css):
+        start = css.index(".device-card {")
+        end = css.index("}", start)
+        return css[start:end]
+
+    assert extract_device_card_block(css_full) != extract_device_card_block(css_half)
+
+
+# ── generate_css — textures ───────────────────────────────────────────────────
+
+
+def test_generate_css_texture_none_sets_no_image():
+    css = generate_css(Theme(texture="none"))
+    bg_block = css[css.index(".app-background {"):][:300]
+    assert "background-image: none" in bg_block
+
+
+def test_generate_css_texture_dots():
+    css = generate_css(Theme(texture="dots"))
+    bg_block = css[css.index(".app-background {"):][:400]
+    assert "radial-gradient" in bg_block
+
+
+def test_generate_css_texture_scanlines():
+    css = generate_css(Theme(texture="scanlines"))
+    bg_block = css[css.index(".app-background {"):][:500]
+    assert "repeating-linear-gradient" in bg_block
+
+
+def test_generate_css_texture_noise():
+    css = generate_css(Theme(texture="noise"))
+    bg_block = css[css.index(".app-background {"):][:700]
+    assert "data:image/svg+xml;base64," in bg_block
+
+
+# ── generate_css — default produces stable output ────────────────────────────
+
+
+def test_generate_css_default_is_deterministic():
+    assert generate_css(Theme()) == generate_css(Theme())
+
+
+def test_generate_css_different_themes_differ():
+    assert generate_css(Theme(accent="#e83535")) != generate_css(Theme(accent="#3b82f6"))
+
+
+# ── ACCENT_PRESETS, BG_PRESETS, and TEXTURES constants ───────────────────────
+
+
+def test_accent_presets_all_valid_hex():
+    from nothing_app.theme import ACCENT_PRESETS
+
+    for color, _ in ACCENT_PRESETS:
+        assert color.startswith("#")
+        assert len(color) == 7
+        hex_to_rgb(color)
+
+
+def test_bg_presets_all_valid_hex():
+    from nothing_app.theme import BG_PRESETS
+
+    for color, _ in BG_PRESETS:
+        assert color.startswith("#")
+        assert len(color) == 7
+        hex_to_rgb(color)
+
+
+def test_textures_keys_match_texture_css():
+    from nothing_app.theme import TEXTURES
+
+    for key, _ in TEXTURES:
+        css = _texture_css(key)
+        assert isinstance(css, str) and len(css) > 0


### PR DESCRIPTION
## Summary

- **Theming system** — accent color (8 presets + custom picker), background color (8 presets + custom picker), window/card opacity sliders, background blur, texture overlays (dots, scanlines, noise). Theme persisted to `~/.config/something-x/theme.json` and applied live via GTK CSS injection.
- **Font selection** — 5 presets (System, Adwaita, iA Writer Quattro S, JetBrains Mono, Omarchy) applied via CSS `font-family` override; resets with the rest of the theme.
- **Device nicknames** — editable name stored in `profiles.json`; used in connect/disconnect notifications.
- **Profile import / export** — single-device JSON round-trip via native file chooser.
- **Notification preferences** — per-event toggles (battery low, connect, disconnect) in a new Settings section.
- **Close vs Quit** — header bar now distinguishes "Close" (hide to tray) from "Quit" (terminate).
