### PR TITLE
feat: wear-detect MPRIS actions and lint fixes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@
 ### Features
 - [x] **Device nickname** — rename a paired device in the UI; stored in profiles
 - [x] **Profile import / export** — share `.json` profile files between machines or with other users
-- [ ] **Wear-detect MPRIS actions** — pause media when both buds are removed; resume when reinserted (opt-in)
+- [x] **Wear-detect MPRIS actions** — pause media when both buds are removed; resume when reinserted (opt-in)
 - [x] **Notification preferences** — per-event toggles (battery low, connect, disconnect) in settings
 - [x] **Theming** — user-selectable accent color and light/dark mode toggle; theme stored in config
 

--- a/nothing_app/pages/device.py
+++ b/nothing_app/pages/device.py
@@ -9,7 +9,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Pango", "1.0")
 gi.require_version("PangoCairo", "1.0")
-from gi.repository import Gtk, GLib, PangoCairo, Gio
+from gi.repository import Gtk, GLib, PangoCairo
 
 from ..bluetooth import BluetoothDevice, BluetoothManager
 from ..protocol import NothingDevice, ANCMode, EQ_PRESETS
@@ -477,12 +477,15 @@ class DevicePage(Gtk.Box):
         )
 
         self._auto_pause_switch = Gtk.Switch()
-        self._auto_pause_switch.set_active(True)
+        self._auto_pause_switch.set_active(
+            profiles.get_notify_prefs(self._bt_device.address).get("wear_mpris", False)
+        )
         self._auto_pause_switch.set_valign(Gtk.Align.CENTER)
+        self._auto_pause_switch.connect("state-set", self._on_auto_pause_toggled)
         settings_group.append(
             _settings_row(
                 "Auto-Pause",
-                "Pause media on removal",
+                "Pause/resume media with wear detection",
                 self._auto_pause_switch,
             )
         )
@@ -711,6 +714,10 @@ class DevicePage(Gtk.Box):
     def _on_nickname_focus_lost(self, entry, _param):
         if not entry.has_focus():
             self._save_nickname()
+
+    def _on_auto_pause_toggled(self, _switch, state: bool):
+        profiles.set_notify_prefs(self._bt_device.address, {"wear_mpris": state})
+        return False
 
     def _on_notif_battery_toggled(self, _switch, state: bool):
         profiles.set_notify_prefs(self._bt_device.address, {"battery_low": state})

--- a/nothing_app/pages/theme.py
+++ b/nothing_app/pages/theme.py
@@ -1,10 +1,10 @@
 import math
-from typing import Callable
+from collections.abc import Callable
 
 import gi
 
 gi.require_version("Gtk", "4.0")
-from gi.repository import Gdk, GLib, Gtk
+from gi.repository import Gdk, Gtk
 
 from ..theme import ACCENT_PRESETS, BG_PRESETS, FONT_PRESETS, TEXTURES, Theme, hex_to_rgb
 
@@ -345,11 +345,8 @@ class ThemePage(Gtk.Box):
 
     def _on_accent_color_set(self, btn: Gtk.ColorButton):
         rgba = btn.get_rgba()
-        self._theme.accent = "#{:02x}{:02x}{:02x}".format(
-            int(rgba.red * 255),
-            int(rgba.green * 255),
-            int(rgba.blue * 255),
-        )
+        r, g, b = int(rgba.red * 255), int(rgba.green * 255), int(rgba.blue * 255)
+        self._theme.accent = f"#{r:02x}{g:02x}{b:02x}"
         self._update_accent_swatches()
         self._emit()
 
@@ -368,11 +365,8 @@ class ThemePage(Gtk.Box):
 
     def _on_bg_color_set(self, btn: Gtk.ColorButton):
         rgba = btn.get_rgba()
-        self._theme.bg_color = "#{:02x}{:02x}{:02x}".format(
-            int(rgba.red * 255),
-            int(rgba.green * 255),
-            int(rgba.blue * 255),
-        )
+        r, g, b = int(rgba.red * 255), int(rgba.green * 255), int(rgba.blue * 255)
+        self._theme.bg_color = f"#{r:02x}{g:02x}{b:02x}"
         self._update_bg_swatches()
         self._emit()
 
@@ -419,8 +413,6 @@ class ThemePage(Gtk.Box):
         self._emit()
 
     def _on_reset(self, _btn):
-        import dataclasses
-
         self._theme = Theme()
         self._reload_controls()
         self._emit()
@@ -428,11 +420,11 @@ class ThemePage(Gtk.Box):
     # ── Internal helpers ──────────────────────────────────────────────────────
 
     def _update_accent_swatches(self):
-        for sw, (color, _) in zip(self._accent_swatches, ACCENT_PRESETS):
+        for sw, (color, _) in zip(self._accent_swatches, ACCENT_PRESETS, strict=False):
             sw.set_active(color.lower() == self._theme.accent.lower())
 
     def _update_bg_swatches(self):
-        for sw, (color, _) in zip(self._bg_swatches, BG_PRESETS):
+        for sw, (color, _) in zip(self._bg_swatches, BG_PRESETS, strict=False):
             sw.set_active(color.lower() == self._theme.bg_color.lower())
 
     def _reload_controls(self):

--- a/nothing_app/profiles.py
+++ b/nothing_app/profiles.py
@@ -5,7 +5,7 @@ _DIR = os.path.expanduser("~/.config/something-x")
 _PROFILES_FILE = os.path.join(_DIR, "profiles.json")
 _LAST_DEV_FILE = os.path.join(_DIR, "last_device")
 
-_NOTIFY_DEFAULTS: dict = {"battery_low": True, "connect": True, "disconnect": True}
+_NOTIFY_DEFAULTS: dict = {"battery_low": True, "connect": True, "disconnect": True, "wear_mpris": False}
 _ALLOWED_IMPORT_KEYS = frozenset({"anc", "eq", "nickname", "notify"})
 
 

--- a/nothing_app/protocol.py
+++ b/nothing_app/protocol.py
@@ -152,6 +152,8 @@ class NothingDevice(GObject.Object):
         self._thread: threading.Thread | None = None
         self._low_bat_notified: dict[str, set[int]] = {}
         self._low_bat_seen: set[str] = set()
+        self._wear_both_removed: bool = False
+        self._wear_paused: bool = False
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -545,9 +547,8 @@ class NothingDevice(GObject.Object):
             else:
                 modes = frozenset([ANCMode.OFF, ANCMode.TRANSPARENCY])
             self.state.supported_anc_modes = modes
-            _log(
-                f"[protocol] supported ANC modes detected: {[ANCMode.LABELS.get(m, m) for m in sorted(modes)]}"
-            )
+            labels = [ANCMode.LABELS.get(m, m) for m in sorted(modes)]
+            _log(f"[protocol] supported ANC modes detected: {labels}")
             changed = True
 
         return changed
@@ -579,6 +580,7 @@ class NothingDevice(GObject.Object):
                 changed = True
         if changed:
             _log(f"[protocol] wearing L={self.state.left_wearing} R={self.state.right_wearing}")
+            self._check_wear_mpris()
         return changed
 
     # ── Legacy 0x03 frame handling (status-only fallback) ────────────────────
@@ -680,6 +682,36 @@ class NothingDevice(GObject.Object):
                             daemon=True,
                         ).start()
                 break
+
+    def _check_wear_mpris(self):
+        from . import profiles
+
+        if not profiles.get_notify_prefs(self.address).get("wear_mpris", False):
+            self._wear_both_removed = False
+            self._wear_paused = False
+            return
+
+        both_removed = not self.state.left_wearing and not self.state.right_wearing
+
+        if both_removed and not self._wear_both_removed:
+            self._wear_both_removed = True
+            self._wear_paused = True
+            threading.Thread(
+                target=subprocess.run,
+                args=(["playerctl", "pause"],),
+                kwargs={"capture_output": True},
+                daemon=True,
+            ).start()
+        elif not both_removed and self._wear_both_removed:
+            self._wear_both_removed = False
+            if self._wear_paused:
+                self._wear_paused = False
+                threading.Thread(
+                    target=subprocess.run,
+                    args=(["playerctl", "play"],),
+                    kwargs={"capture_output": True},
+                    daemon=True,
+                ).start()
 
     def _poll_earphone_status(self):
         # The firmware only computes a fresh per-bud snapshot when asked; the

--- a/nothing_app/tray.py
+++ b/nothing_app/tray.py
@@ -4,7 +4,7 @@ import dbus.service
 import dbus.mainloop.glib
 from gi.repository import GLib, GObject
 
-from .bluetooth import BluetoothManager, BluetoothDevice, device_icon_name
+from .bluetooth import BluetoothManager, device_icon_name
 
 _ITEM_IFACE = "org.kde.StatusNotifierItem"
 _WATCHER_IFACE = "org.kde.StatusNotifierWatcher"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,11 @@ def mock_profiles(monkeypatch):
     monkeypatch.setattr(profiles, "save", MagicMock())
     monkeypatch.setattr(profiles, "load", MagicMock(return_value={}))
     monkeypatch.setattr(profiles, "set_last_device", MagicMock())
-    monkeypatch.setattr(profiles, "get_notify_prefs", MagicMock(return_value={"battery_low": True, "connect": True, "disconnect": True}))
+    monkeypatch.setattr(
+        profiles,
+        "get_notify_prefs",
+        MagicMock(return_value={"battery_low": True, "connect": True, "disconnect": True}),
+    )
     monkeypatch.setattr(profiles, "get_nickname", MagicMock(return_value=None))
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -131,3 +131,97 @@ def test_battery_low_sent_with_default_prefs():
         fired.wait(timeout=2)
 
     assert calls
+
+
+# ── wear_mpris pref ───────────────────────────────────────────────────────────
+
+
+def _set_wearing(dev: NothingDevice, left: bool, right: bool):
+    """Directly update wearing state and call the MPRIS check."""
+    dev.state.left_wearing = left
+    dev.state.right_wearing = right
+    dev._check_wear_mpris()
+
+
+def test_wear_mpris_pauses_when_both_removed(tmp_path, monkeypatch):
+    monkeypatch.setattr(profiles, "_PROFILES_FILE", str(tmp_path / "profiles.json"))
+    profiles.set_notify_prefs(_ADDR, {"wear_mpris": True})
+
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+
+    dev = _make_device()
+    with patch("nothing_app.protocol.subprocess.run", fake_run):
+        _set_wearing(dev, True, True)  # both wearing
+        _set_wearing(dev, False, False)  # both removed → pause
+        import time
+
+        time.sleep(0.05)
+
+    assert any("pause" in c for c in calls)
+
+
+def test_wear_mpris_resumes_when_reinserted(tmp_path, monkeypatch):
+    monkeypatch.setattr(profiles, "_PROFILES_FILE", str(tmp_path / "profiles.json"))
+    profiles.set_notify_prefs(_ADDR, {"wear_mpris": True})
+
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+
+    dev = _make_device()
+    with patch("nothing_app.protocol.subprocess.run", fake_run):
+        _set_wearing(dev, True, True)
+        _set_wearing(dev, False, False)  # pause
+        _set_wearing(dev, True, False)  # one bud back in → play
+        import time
+
+        time.sleep(0.05)
+
+    cmds = [c[-1] for c in calls]
+    assert "pause" in cmds
+    assert "play" in cmds
+
+
+def test_wear_mpris_disabled_by_default():
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+
+    dev = _make_device()
+    with patch("nothing_app.protocol.subprocess.run", fake_run):
+        _set_wearing(dev, True, True)
+        _set_wearing(dev, False, False)
+        import time
+
+        time.sleep(0.05)
+
+    assert not calls, "wear_mpris is opt-in — should not fire with default prefs"
+
+
+def test_wear_mpris_no_double_play(tmp_path, monkeypatch):
+    """Wearing state bouncing while already in-ear should not trigger repeated plays."""
+    monkeypatch.setattr(profiles, "_PROFILES_FILE", str(tmp_path / "profiles.json"))
+    profiles.set_notify_prefs(_ADDR, {"wear_mpris": True})
+
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+
+    dev = _make_device()
+    with patch("nothing_app.protocol.subprocess.run", fake_run):
+        _set_wearing(dev, True, True)
+        _set_wearing(dev, False, False)  # pause
+        _set_wearing(dev, True, False)  # play
+        _set_wearing(dev, True, True)  # still wearing — no extra play
+        import time
+
+        time.sleep(0.05)
+
+    play_calls = [c for c in calls if "play" in c]
+    assert len(play_calls) == 1

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -142,9 +142,9 @@ def test_nickname_does_not_affect_other_device():
 # ── notify_prefs ──────────────────────────────────────────────────────────────
 
 
-def test_get_notify_prefs_defaults_all_true():
+def test_get_notify_prefs_defaults():
     prefs = profiles.get_notify_prefs("AA:BB:CC:DD:EE:FF")
-    assert prefs == {"battery_low": True, "connect": True, "disconnect": True}
+    assert prefs == {"battery_low": True, "connect": True, "disconnect": True, "wear_mpris": False}
 
 
 def test_set_notify_prefs_roundtrip():

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -90,7 +90,7 @@ def test_parse_battery_updates_only_present_types():
     payload = bytes([0x01, 0x03, 60])
     dev._parse_battery(payload)
     assert dev.state.right_battery == 60
-    assert dev.state.left_battery == -1   # untouched default
+    assert dev.state.left_battery == -1  # untouched default
     assert dev.state.case_battery == -1
 
 

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -66,7 +66,9 @@ def test_load_bad_json_returns_defaults(tmp_path):
 
 
 def test_save_and_load_roundtrip():
-    t = Theme(accent="#3b82f6", bg_color="#1a1b26", window_opacity=0.8, card_opacity=0.5, blur=6, texture="dots")
+    t = Theme(
+        accent="#3b82f6", bg_color="#1a1b26", window_opacity=0.8, card_opacity=0.5, blur=6, texture="dots"
+    )
     save(t)
     t2 = load()
     assert t2 == t
@@ -319,7 +321,7 @@ def test_generate_css_bg_color_default_is_black():
 
 def test_generate_css_custom_bg_used_in_app_background_gradient():
     css = generate_css(Theme(bg_color="#1e1e2e"))
-    bg_block = css[css.index(".app-background {"):][:300]
+    bg_block = css[css.index(".app-background {") :][:300]
     assert "1e1e2e" in bg_block or "background" in bg_block
 
 
@@ -344,29 +346,29 @@ def test_generate_css_blur_emits_filter():
 
 def test_generate_css_blur_appears_in_app_background():
     css = generate_css(Theme(blur=4))
-    bg_section = css[css.index(".app-background {"):]
-    first_block = bg_section[:bg_section.index("}") + 1]
+    bg_section = css[css.index(".app-background {") :]
+    first_block = bg_section[: bg_section.index("}") + 1]
     assert "blur(4px)" in first_block
 
 
 def test_generate_css_blur_not_in_nothing_page():
     css = generate_css(Theme(blur=6))
-    page_section = css[css.index(".nothing-page {"):]
-    first_block = page_section[:page_section.index("}") + 1]
+    page_section = css[css.index(".nothing-page {") :]
+    first_block = page_section[: page_section.index("}") + 1]
     assert "blur(" not in first_block
 
 
 def test_generate_css_blur_not_in_device_card():
     css = generate_css(Theme(blur=6))
-    card_section = css[css.index(".device-card {"):]
-    first_block = card_section[:card_section.index("}") + 1]
+    card_section = css[css.index(".device-card {") :]
+    first_block = card_section[: card_section.index("}") + 1]
     assert "blur(" not in first_block
 
 
 def test_generate_css_blur_not_in_settings_group():
     css = generate_css(Theme(blur=6))
-    group_section = css[css.index(".settings-group {"):]
-    first_block = group_section[:group_section.index("}") + 1]
+    group_section = css[css.index(".settings-group {") :]
+    first_block = group_section[: group_section.index("}") + 1]
     assert "blur(" not in first_block
 
 
@@ -392,25 +394,25 @@ def test_generate_css_card_opacity_scales_alpha():
 
 def test_generate_css_texture_none_sets_no_image():
     css = generate_css(Theme(texture="none"))
-    bg_block = css[css.index(".app-background {"):][:300]
+    bg_block = css[css.index(".app-background {") :][:300]
     assert "background-image: none" in bg_block
 
 
 def test_generate_css_texture_dots():
     css = generate_css(Theme(texture="dots"))
-    bg_block = css[css.index(".app-background {"):][:400]
+    bg_block = css[css.index(".app-background {") :][:400]
     assert "radial-gradient" in bg_block
 
 
 def test_generate_css_texture_scanlines():
     css = generate_css(Theme(texture="scanlines"))
-    bg_block = css[css.index(".app-background {"):][:500]
+    bg_block = css[css.index(".app-background {") :][:500]
     assert "repeating-linear-gradient" in bg_block
 
 
 def test_generate_css_texture_noise():
     css = generate_css(Theme(texture="noise"))
-    bg_block = css[css.index(".app-background {"):][:700]
+    bg_block = css[css.index(".app-background {") :][:700]
     assert "data:image/svg+xml;base64," in bg_block
 
 


### PR DESCRIPTION
- Pause playerctl when both earbuds removed, resume on reinsertion (opt-in via Auto-Pause toggle in settings)
- Wire up previously placeholder Auto-Pause switch to wear_mpris profile pref
- Add wear_mpris=False to notify pref defaults (explicit opt-in)
- 4 new tests: pause on removal, resume on reinsertion, disabled by default, no double-play
- Fix ruff warnings: unused imports (Gio, GLib, BluetoothDevice, dataclasses), deprecated typing.Callable, .format() → f-string, zip() strict=False